### PR TITLE
fix(p115strmhelper): make rename_dict_supplement chain-aware

### DIFF
--- a/plugins.v2/p115strmhelper/__init__.py
+++ b/plugins.v2/p115strmhelper/__init__.py
@@ -1,3 +1,4 @@
+import re
 from time import sleep
 from copy import deepcopy
 from dataclasses import asdict
@@ -1776,10 +1777,21 @@ class P115StrmHelper(_PluginBase):
         mediasyncdel_helper = MediaSyncDelHelper()
         mediasyncdel_helper.download_file_del_sync(event)
 
-    @eventmanager.register(ChainEventType.TransferRename)
+    @eventmanager.register(ChainEventType.TransferRename, priority=5)
     def rename_dict_supplement(self, event: Event) -> None:
         """
         媒体数据补充
+
+        通过 ffprobe / 中心化接口获取真实媒体信息（如 effect=SDR/HDR、视频/音频
+        编码等），写回 ``event_data.rename_dict``，再据此生成新的 ``updated_str``。
+
+        本处理器使用 ``priority=5`` 强制在默认 priority=10 的字符串改写类插件
+        （如"智能重命名"）之前运行，便于后者承接补充后的字段做大小写、词替换
+        等链式叠加。
+
+        当上游事件链已经写入 ``updated_str`` 时（外部插件以更小的 priority 抢先
+        执行），本处理器不再对整串重渲，而是基于 ``rename_dict`` 中字段的旧值对
+        上游字符串做单词边界替换，避免抹掉上游的字符串级改动。
         """
         if not configer.enabled:
             return
@@ -1805,6 +1817,9 @@ class P115StrmHelper(_PluginBase):
         if Path(source_path).suffix.lower() not in settings.RMT_MEDIAEXT:
             logger.debug("【媒体数据补充】文件后缀不是媒体文件，跳过本次重命名补全")
             return
+
+        # 记录字段变更前的旧值快照：链式补丁路径下用于在上游已渲染串里定位被改字段
+        original_rename_dict: Dict[str, Any] = deepcopy(data.rename_dict)
 
         def share_strm_center(url: str) -> Optional[Dict[str, Any]]:
             for i in ["P115StrmHelper", "share_code=", "receive_code=", "id="]:
@@ -1884,6 +1899,8 @@ class P115StrmHelper(_PluginBase):
         overwrite_mode = configer.rename_dict_supplement_overwrite_mode
         if overwrite_mode not in ("fill_missing", "always"):
             overwrite_mode = "fill_missing"
+        # 记录本次实际写入的字段，供链式补丁路径定位
+        applied_fields: Dict[str, Any] = {}
         for key, value in media_info.items():
             if not value:
                 continue
@@ -1892,23 +1909,88 @@ class P115StrmHelper(_PluginBase):
                 if cur is not None and not (isinstance(cur, str) and cur.strip() == ""):
                     continue
             data.rename_dict[key] = value
+            applied_fields[key] = value
             changed = True
         if not changed:
             return
 
-        try:
-            new_render = Template(data.template_string).render(data.rename_dict)
-        except Exception as e:
-            logger.error(
-                "【媒体数据补充】模板重新渲染失败: %s",
-                e,
-                exc_info=True,
+        upstream_updated = bool(data.updated and data.updated_str)
+        if upstream_updated:
+            # 上游已写过 updated_str：基于其结果做差量补丁，避免重渲覆盖上游字符串级改动
+            new_render = self.__apply_rename_dict_patch_to_string(
+                base_str=data.updated_str,
+                original_rename_dict=original_rename_dict,
+                applied_fields=applied_fields,
+                upstream_source=data.source,
             )
-            return
+            if new_render == data.updated_str:
+                # 没能定位到任何替换锚点，链式补丁未生效；不覆盖上游结果
+                logger.debug(
+                    "【媒体数据补充】上游已写入 updated_str 且本次补充字段在串中无锚点，"
+                    "保留上游结果不变（上游来源：%s）",
+                    data.source,
+                )
+                return
+        else:
+            # 没有上游写入：按原逻辑用 template_string 整体重渲
+            try:
+                new_render = Template(data.template_string).render(data.rename_dict)
+            except Exception as e:
+                logger.error(
+                    "【媒体数据补充】模板重新渲染失败: %s",
+                    e,
+                    exc_info=True,
+                )
+                return
 
         data.updated = True
         data.updated_str = new_render
         data.source = "媒体数据补充"
+
+    @staticmethod
+    def __apply_rename_dict_patch_to_string(
+        base_str: str,
+        original_rename_dict: Dict[str, Any],
+        applied_fields: Dict[str, Any],
+        upstream_source: Optional[str] = None,
+    ) -> str:
+        """
+        在上游已渲染串上做单词边界级差量替换，避免链式覆盖。
+
+        仅对"旧值非空"的字段尝试 ``old_value -> new_value`` 替换；新增字段
+        （旧值为空）无法在已渲染串里定位锚点，本方法不会强行插入。
+
+        :param base_str: 上游写入的 ``updated_str``，作为替换基础。
+        :param original_rename_dict: 本插件改写 ``rename_dict`` 前的字段快照。
+        :param applied_fields: 本次实际改写的字段及其新值。
+        :param upstream_source: 上游处理器名称，仅用于日志。
+        :return: 应用差量替换后的字符串；若无可应用项则原样返回。
+        """
+        patched = base_str
+        skipped: List[str] = []
+        for key, new_value in applied_fields.items():
+            old_value = original_rename_dict.get(key)
+            if old_value is None or (isinstance(old_value, str) and not old_value.strip()):
+                skipped.append(key)
+                continue
+            old_token = str(old_value)
+            new_token = str(new_value)
+            if old_token == new_token:
+                continue
+            # 单词边界替换，避免误伤同名子串（例如 audioCodec=AAC 不应替换文件名中的随机 "AAC" 子串）
+            pattern = rf"(?<![A-Za-z0-9]){re.escape(old_token)}(?![A-Za-z0-9])"
+            new_patched, count = re.subn(pattern, new_token, patched)
+            if count:
+                patched = new_patched
+            else:
+                skipped.append(key)
+        if skipped:
+            logger.debug(
+                "【媒体数据补充】链式补丁跳过字段 %s（上游来源：%s）",
+                ",".join(skipped),
+                upstream_source,
+            )
+        return patched
 
     @eventmanager.register(ChainEventType.TransferIntercept)
     def intercept_if_exists_in_library(self, event: Event) -> None:


### PR DESCRIPTION
## 背景

`rename_dict_supplement` 当前在补充媒体字段后，无条件用 `Template(data.template_string).render(data.rename_dict)` 整体重渲并写回 `updated_str`。

这会和其它已经在 `ChainEventType.TransferRename` 链上写入 `updated_str` 的字符串改写类插件（典型如 [智能重命名 SmartRename](https://github.com/InfinityPacer/MoviePilot-Plugins/blob/main/plugins.v2/smartrename/__init__.py)）发生**双向覆盖**：

- 若 `rename_dict_supplement` 后跑：用原始 `template_string` 重渲，会丢掉上游做的大小写、词替换、自定义分隔符等字符串级改动；
- 若 `rename_dict_supplement` 先跑：自己写入 `updated_str` 与 `updated=True`，但下游某些字符串改写插件遇到 `event_data.updated == True` 会直接 short-circuit return（例如 SmartRename 在 v1.4 及之前就是这个行为），导致字段补充虽然进入了文件名，但字符串级修饰被全部跳过。

实际复现见上游 issue：

- DDSRem-Dev/MoviePilot-Plugins#344
- InfinityPacer/MoviePilot-Plugins#180

用户表现：源种 `Marriage.Toxin.S01E01.2026.1080p.CR.WEB-DL.x264.AAC.mkv` 在两个插件同启用时，要么补到 SDR 但丢了 `WEB-DL→Web-DL` / `x264→H.264` 的词替换，要么走到智能重命名结果但丢了 SDR。

## 改动

1. **显式提高优先级**：`@eventmanager.register(ChainEventType.TransferRename, priority=5)`。MoviePilot 链式事件按 priority 升序执行（`app/core/event.py:200-202`），默认 10；本插件做的是"字段补充 → 重渲"，应当跑在字符串改写类插件之前，让后者承接补充后的字段做叠加。
2. **进入时记录 `rename_dict` 快照**：`original_rename_dict = deepcopy(data.rename_dict)`，用于后续在上游已渲染串里定位被改字段。
3. **渲染策略按上游链式状态分支**：
   - **上游未写入 `updated_str`**（`not data.updated or not data.updated_str`）：维持原行为，用 `template_string` 整体重渲；
   - **上游已写入 `updated_str`**：调用新增的 `__apply_rename_dict_patch_to_string`，在上游字符串上对"旧值非空的字段"做**单词边界级 `re.subn`** 差量替换，不再走整体重渲，避免覆盖上游字符串级改动；新增字段（旧值为空）由于在已渲染串里无锚点，会跳过并打 debug 日志。
4. **写回保护**：链式补丁路径下若没能定位到任何替换锚点（即 `new_render == data.updated_str`），不重写 `updated / updated_str / source`，保持上游结果不变。

本 PR 仅修复链式协作行为，未变更对外功能，按维护者要求不动 `version.py` 与 `package.v2.json`，版本号留由维护者发版时统一处理。

## 验证

- `python3 -m py_compile plugins.v2/p115strmhelper/__init__.py` 通过；
- 逻辑过 issue 中的两组实测日志：
  - 仅启用本插件（priority=5 生效后等价于旧路径）：`Initial render → ffprobe 补 SDR → 走非链式分支 → Template 重渲 → updated_str 含 SDR`，行为与现状一致；
  - 同时启用智能重命名（priority=10）：本插件先跑写 `updated_str = "...1080p SDR x264 AAC.mkv"`；智能重命名（v1.5 起支持链式）承接做 `WEB-DL→Web-DL / x264→H.264` → 最终落盘 `...Web-DL Crunchyroll 1080p SDR H.264 AAC.mkv`，两边诉求同时满足。
- 智能重命名侧的链式承接改动已发布为 v1.5，见 [InfinityPacer/MoviePilot-Plugins@1eba758](https://github.com/InfinityPacer/MoviePilot-Plugins/commit/1eba758)。

## 兼容性

- 仅启用本插件、未启用任何字符串改写类插件的用户：行为与现状完全一致（上游未写 `updated_str` 时仍走整体重渲）。
- 智能重命名旧版本（v1.4 及之前）仍会因为 `event_data.updated == True` short-circuit 跳过；这是 SmartRename v1.5 才修复的链式承接能力，需要用户同步升级。本 PR 不依赖该升级——单独装本 PR 也只会让本插件先跑，行为退化为"补字段 + 重渲 → 智能重命名跳过"，与升级前等价。
- 链式补丁路径下"新增字段无锚点"无法注入；这是字符串补丁的固有限制，已通过把本插件提到 priority=5 跑在前面来规避主路径。

Closes DDSRem-Dev/MoviePilot-Plugins#344
Refs InfinityPacer/MoviePilot-Plugins#180

本 PR 为 Claude Code 协作提交。