### PR TITLE
fix(ffprobenamingsupplement): make on_transfer_rename chain-aware

### DIFF
--- a/plugins.v2/ffprobenamingsupplement/__init__.py
+++ b/plugins.v2/ffprobenamingsupplement/__init__.py
@@ -1,3 +1,5 @@
+import re
+from copy import deepcopy
 from json import JSONDecodeError, loads
 from pathlib import Path
 from subprocess import TimeoutExpired, run
@@ -773,8 +775,23 @@ class FFprobeNamingSupplement(_PluginBase):
             logger.warning("【ffprobe命名补充】ffprobe JSON 解析失败: %s", e)
             return None
 
-    @eventmanager.register(ChainEventType.TransferRename, priority=20)
+    @eventmanager.register(ChainEventType.TransferRename, priority=6)
     def on_transfer_rename(self, event: Event) -> None:
+        """
+        处理 TransferRename 链式事件，使用本地 ffprobe 结果补充重命名字段。
+
+        本处理器以 ``priority=6`` 注册：
+
+        - 跑在默认 ``priority=10`` 的字符串改写类插件（如智能重命名）之前，
+          便于后者承接补充后的字段做大小写、词替换等链式叠加；
+        - 比同类字段补充插件（115网盘STRM助手，``priority=5``）稍晚一档，
+          作为本地 ffprobe 兜底路径，避免与中心化媒体信息提取竞争主路径。
+
+        当上游事件链已经写入 ``updated_str`` 时，本处理器不再用 ``template_string``
+        对整串重渲，而是基于 ``rename_dict`` 中字段的旧值对上游字符串做单词
+        边界级替换，避免覆盖上游字符串级改动；新增字段（旧值为空）在上游
+        已渲染串里没有锚点，会跳过并打 debug 日志。
+        """
         if not self._enabled:
             return
         data = event.event_data
@@ -825,24 +842,70 @@ class FFprobeNamingSupplement(_PluginBase):
             )
             return
 
+        # 记录字段变更前的旧值快照：链式补丁路径下用于在上游已渲染串里定位被改字段
+        original_rename_dict: Dict[str, Any] = deepcopy(rename_dict)
+
         changed = False
+        # 记录本次实际写入的字段，供链式补丁路径定位
+        applied_fields: Dict[str, Any] = {}
         for key, val in fields.items():
             if cls._should_apply_key(self._overwrite_mode, key, rename_dict, val):
                 rename_dict[key] = val
+                applied_fields[key] = val
                 changed = True
 
         if not changed:
             return
 
-        try:
-            new_render = Template(data.template_string).render(rename_dict)
-        except Exception as e:
-            logger.error(
-                "【ffprobe命名补充】模板重新渲染失败: %s",
-                e,
-                exc_info=True,
-            )
-            return
+        upstream_updated = bool(data.updated and data.updated_str)
+        if upstream_updated:
+            # 上游已写过 updated_str：基于其结果做差量补丁，避免重渲覆盖上游字符串级改动
+            patched = data.updated_str
+            skipped: List[str] = []
+            for key, new_value in applied_fields.items():
+                old_value = original_rename_dict.get(key)
+                if old_value is None or (
+                    isinstance(old_value, str) and not old_value.strip()
+                ):
+                    skipped.append(key)
+                    continue
+                old_token = str(old_value)
+                new_token = str(new_value)
+                if old_token == new_token:
+                    continue
+                # 单词边界替换，避免误伤同名子串（例如 audioCodec=AAC 不应替换文件名中的随机 "AAC" 子串）
+                pattern = rf"(?<![A-Za-z0-9]){re.escape(old_token)}(?![A-Za-z0-9])"
+                new_patched, count = re.subn(pattern, new_token, patched)
+                if count:
+                    patched = new_patched
+                else:
+                    skipped.append(key)
+            if skipped:
+                logger.debug(
+                    "【ffprobe命名补充】链式补丁跳过字段 %s（上游来源：%s）",
+                    ",".join(skipped),
+                    data.source,
+                )
+            if patched == data.updated_str:
+                # 没能定位到任何替换锚点，链式补丁未生效；不覆盖上游结果
+                logger.debug(
+                    "【ffprobe命名补充】上游已写入 updated_str 且本次补充字段在串中无锚点，"
+                    "保留上游结果不变（上游来源：%s）",
+                    data.source,
+                )
+                return
+            new_render = patched
+        else:
+            # 没有上游写入：按原逻辑用 template_string 整体重渲
+            try:
+                new_render = Template(data.template_string).render(rename_dict)
+            except Exception as e:
+                logger.error(
+                    "【ffprobe命名补充】模板重新渲染失败: %s",
+                    e,
+                    exc_info=True,
+                )
+                return
 
         data.updated = True
         data.updated_str = new_render


### PR DESCRIPTION
## 背景

`ffprobenamingsupplement.on_transfer_rename` 当前注册时 `priority=20`（晚于默认 10），并在补充字段后无条件用 `Template(data.template_string).render(rename_dict)` 整体重渲、写回 `updated_str`。

这会和默认 priority=10 的字符串改写类插件（典型如 [SmartRename 智能重命名](https://github.com/InfinityPacer/MoviePilot-Plugins/blob/main/plugins.v2/smartrename/__init__.py)）形成**必然覆盖**：智能重命名先跑写入大小写、词替换后的 `updated_str`，本插件再跑用原始模板重渲，把上游字符串级改动全部抹掉。

结构上和姊妹插件 `p115strmhelper.rename_dict_supplement` 是同一类问题，详细分析与对照见 #345（p115 侧同构修复）以及上游侧 issue [InfinityPacer/MoviePilot-Plugins#180](https://github.com/InfinityPacer/MoviePilot-Plugins/issues/180)。

## 改动

按与 #345 同构的方式调整，未抽取共享 helper（保持插件目录互不依赖）：

1. **`priority=20` → `priority=6`**：
   - 跑在默认 `priority=10` 的字符串改写类插件之前，让后者承接补充后的字段做叠加；
   - 比 #345 中 `p115strmhelper` 的 `priority=5` 稍晚一档，保持"中心化主路径 → 本地 ffprobe 兜底"的天然顺序（同时启用时 p115 先跑写字段，本插件在 fill_missing 模式下会因为字段已就位直接早退；在 always 模式下走链式补丁分支，单词边界 + 同值跳过保证不会抖动）。
2. **进入主逻辑后 `deepcopy(rename_dict)` 留快照**，作为后续在上游已渲染串里定位被改字段的依据。
3. **`applied_fields` 显式记录本次实际写入的字段**，与 `original_rename_dict` 配合用于差量替换。
4. **按 `data.updated and data.updated_str` 分支决定渲染策略**：
   - 上游未写入：维持原行为，`Template.render` 整体重渲；
   - 上游已写入：在 `data.updated_str` 上对"旧值非空的字段"做**单词边界 `re.subn` 替换**，旧值为空的字段（在已渲染串里无锚点）跳过并打 debug 日志。
5. **写回保护**：链式补丁路径下若没能定位到任何替换锚点（`patched == data.updated_str`），不重写 `updated / updated_str / source`，保留上游结果。
6. **顶部 import 新增** `re` 与 `from copy import deepcopy`。
7. **版本号不变**：本次仅修复链式协作行为，未变更对外功能，按维护者要求不动 `version.py` 与 `package.v2.json.history`。

## 验证

- `python3 -m py_compile plugins.v2/ffprobenamingsupplement/__init__.py` 通过。
- 与 #345 同构的逻辑过本地推演：
  - 仅本插件启用：上游 `data.updated=False` → 走非链式分支，`Template.render` 重渲，行为等价于现状（差别仅在 priority 从 20 调到 6，对纯单插件场景无影响）；
  - 与 `smartrename` v1.5 同启用：本插件先跑写 `updated_str = "...SDR x264 AAC.mkv"`；smartrename 承接做 `WEB-DL→Web-DL / x264→H.264` → 最终落盘 `...Web-DL ... 1080p SDR H.264 AAC.mkv`；
  - 与 `p115strmhelper`（#345 版本）同启用：p115 priority=5 先跑、本插件 priority=6 后跑。`fill_missing` 模式下本插件因为 `_should_apply_key` 拒绝覆盖已填字段直接退出；`always` 模式下走链式补丁，单词边界级替换 + 同值跳过保证无抖动；
  - 三个插件同启用：p115(5) → ffprobe(6) → smartrename(10)，链式承接，行为符合预期。

## 兼容性

- `priority=20 → 6` 的调整对单独启用本插件的用户无可观察影响（场景下没有同时跑的处理器，顺序无关）。
- 与 smartrename 旧版本（v1.4 及之前，遇 `event_data.updated == True` 会 short-circuit return）同启用时：本插件先跑写完字段后，smartrename 旧版会跳过字符串级改动；这是 smartrename 自身的 chain 短路问题，已在 [smartrename v1.5 (InfinityPacer/MoviePilot-Plugins@1eba758)](https://github.com/InfinityPacer/MoviePilot-Plugins/commit/1eba758) 修复，需用户同步升级。本 PR 不依赖该升级——单独装本 PR 行为退化为"补字段 + 重渲 → 智能重命名跳过"，与 priority=20 时一致。
- 链式补丁路径下"新增字段无锚点"无法注入；这是字符串补丁的固有限制，已通过把本插件提到 `priority=6` 跑在前面来规避主路径。

Refs DDSRem-Dev/MoviePilot-Plugins#345
Refs InfinityPacer/MoviePilot-Plugins#180

本 PR 为 Claude Code 协作提交。