### PR TITLE
feat: migrate rename supplement plugins to TransferRenameBuild

### DIFF
--- a/plugins.v2/ffprobenamingsupplement/__init__.py
+++ b/plugins.v2/ffprobenamingsupplement/__init__.py
@@ -1,19 +1,15 @@
-from re import escape as re_escape, subn as re_subn
-from copy import deepcopy
 from json import JSONDecodeError, loads
 from pathlib import Path
 from subprocess import TimeoutExpired, run
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote
 
-from jinja2 import Template
-
 from app.core.cache import TTLCache
 from app.core.config import settings
 from app.core.event import Event, eventmanager
 from app.log import logger
 from app.plugins import _PluginBase
-from app.schemas import TransferRenameEventData, FileItem
+from app.schemas import FileItem, TransferRenameBuildEventData
 from app.schemas.types import ChainEventType
 
 
@@ -775,30 +771,21 @@ class FFprobeNamingSupplement(_PluginBase):
             logger.warning("【ffprobe命名补充】ffprobe JSON 解析失败: %s", e)
             return None
 
-    @eventmanager.register(ChainEventType.TransferRename, priority=6)
-    def on_transfer_rename(self, event: Event) -> None:
+    @eventmanager.register(ChainEventType.TransferRenameBuild)
+    def on_transfer_rename_build(self, event: Event) -> None:
         """
-        处理 TransferRename 链式事件，使用本地 ffprobe 结果补充重命名字段。
+        处理 TransferRenameBuild 链式事件，在主程序首次渲染前把 ffprobe
+        解析到的字段写入 rename_dict。
 
-        本处理器以 ``priority=6`` 注册：
-
-        - 跑在默认 ``priority=10`` 的字符串改写类插件（如智能重命名）之前，
-          便于后者承接补充后的字段做大小写、词替换等链式叠加；
-        - 比同类字段补充插件（115网盘STRM助手，``priority=5``）稍晚一档，
-          作为本地 ffprobe 兜底路径，避免与中心化媒体信息提取竞争主路径。
-
-        当上游事件链已经写入 ``updated_str`` 时，本处理器不再用 ``template_string``
-        对整串重渲，而是基于 ``rename_dict`` 中字段的旧值对上游字符串做单词
-        边界级替换，避免覆盖上游字符串级改动；新增字段（旧值为空）在上游
-        已渲染串里没有锚点，会跳过并打 debug 日志。
+        与渲染后的 TransferRename 字符串改写类插件天然分层、互不冲突。
         """
         if not self._enabled:
             return
         data = event.event_data
-        if not isinstance(data, TransferRenameEventData):
+        if not isinstance(data, TransferRenameBuildEventData):
             return
-        source_path: Optional[str] = getattr(data, "source_path", None)
-        source_item: Optional[FileItem] = getattr(data, "source_item", None)
+        source_path: Optional[str] = data.source_path
+        source_item: Optional[FileItem] = data.source_item
         if not source_path or not str(source_path).strip():
             logger.debug("【ffprobe命名补充】source_path 为空，跳过本次重命名补全")
             return
@@ -842,71 +829,6 @@ class FFprobeNamingSupplement(_PluginBase):
             )
             return
 
-        # 记录字段变更前的旧值快照：链式补丁路径下用于在上游已渲染串里定位被改字段
-        original_rename_dict: Dict[str, Any] = deepcopy(rename_dict)
-
-        changed = False
-        # 记录本次实际写入的字段，供链式补丁路径定位
-        applied_fields: Dict[str, Any] = {}
         for key, val in fields.items():
             if cls._should_apply_key(self._overwrite_mode, key, rename_dict, val):
                 rename_dict[key] = val
-                applied_fields[key] = val
-                changed = True
-
-        if not changed:
-            return
-
-        upstream_updated = bool(data.updated and data.updated_str)
-        if upstream_updated:
-            # 上游已写过 updated_str：基于其结果做差量补丁，避免重渲覆盖上游字符串级改动
-            patched = data.updated_str
-            skipped: List[str] = []
-            for key, new_value in applied_fields.items():
-                old_value = original_rename_dict.get(key)
-                if old_value is None or (
-                    isinstance(old_value, str) and not old_value.strip()
-                ):
-                    skipped.append(key)
-                    continue
-                old_token = str(old_value)
-                new_token = str(new_value)
-                if old_token == new_token:
-                    continue
-                # 单词边界替换，避免误伤同名子串（例如 audioCodec=AAC 不应替换文件名中的随机 "AAC" 子串）
-                pattern = rf"(?<![A-Za-z0-9]){re_escape(old_token)}(?![A-Za-z0-9])"
-                new_patched, count = re_subn(pattern, new_token, patched)
-                if count:
-                    patched = new_patched
-                else:
-                    skipped.append(key)
-            if skipped:
-                logger.debug(
-                    "【ffprobe命名补充】链式补丁跳过字段 %s（上游来源：%s）",
-                    ",".join(skipped),
-                    data.source,
-                )
-            if patched == data.updated_str:
-                # 没能定位到任何替换锚点，链式补丁未生效；不覆盖上游结果
-                logger.debug(
-                    "【ffprobe命名补充】上游已写入 updated_str 且本次补充字段在串中无锚点，"
-                    "保留上游结果不变（上游来源：%s）",
-                    data.source,
-                )
-                return
-            new_render = patched
-        else:
-            # 没有上游写入：按原逻辑用 template_string 整体重渲
-            try:
-                new_render = Template(data.template_string).render(rename_dict)
-            except Exception as e:
-                logger.error(
-                    "【ffprobe命名补充】模板重新渲染失败: %s",
-                    e,
-                    exc_info=True,
-                )
-                return
-
-        data.updated = True
-        data.updated_str = new_render
-        data.source = "ffprobe命名补充"

--- a/plugins.v2/p115strmhelper/__init__.py
+++ b/plugins.v2/p115strmhelper/__init__.py
@@ -1,4 +1,3 @@
-from re import escape as re_escape, subn as re_subn
 from time import sleep
 from copy import deepcopy
 from dataclasses import asdict
@@ -13,7 +12,7 @@ from app.plugins import _PluginBase
 from app.schemas import (
     FileItem,
     NotificationType,
-    TransferRenameEventData,
+    TransferRenameBuildEventData,
     TransferOverwriteCheckEventData,
     TransferInterceptEventData,
 )
@@ -23,7 +22,6 @@ from app.helper.directory import DirectoryHelper
 from app.chain.storage import StorageChain
 
 from apscheduler.triggers.cron import CronTrigger
-from jinja2 import Template
 from fastapi import Request
 from p115center import P115Center
 
@@ -1777,21 +1775,16 @@ class P115StrmHelper(_PluginBase):
         mediasyncdel_helper = MediaSyncDelHelper()
         mediasyncdel_helper.download_file_del_sync(event)
 
-    @eventmanager.register(ChainEventType.TransferRename, priority=5)
+    @eventmanager.register(ChainEventType.TransferRenameBuild)
     def rename_dict_supplement(self, event: Event) -> None:
         """
         媒体数据补充
 
-        通过 ffprobe / 中心化接口获取真实媒体信息（如 effect=SDR/HDR、视频/音频
-        编码等），写回 ``event_data.rename_dict``，再据此生成新的 ``updated_str``。
+        响应主程序渲染前的 TransferRenameBuild 事件，通过 ffprobe / 中心化接口
+        获取真实媒体信息（如 effect=SDR/HDR、视频/音频编码等），写回
+        ``event_data.rename_dict``。
 
-        本处理器使用 ``priority=5`` 强制在默认 priority=10 的字符串改写类插件
-        （如"智能重命名"）之前运行，便于后者承接补充后的字段做大小写、词替换
-        等链式叠加。
-
-        当上游事件链已经写入 ``updated_str`` 时（外部插件以更小的 priority 抢先
-        执行），本处理器不再对整串重渲，而是基于 ``rename_dict`` 中字段的旧值对
-        上游字符串做单词边界替换，避免抹掉上游的字符串级改动。
+        与渲染后的 TransferRename 字符串改写类插件天然分层、互不冲突。
         """
         if not configer.enabled:
             return
@@ -1799,10 +1792,10 @@ class P115StrmHelper(_PluginBase):
             return
 
         data = event.event_data
-        if not isinstance(data, TransferRenameEventData):
+        if not isinstance(data, TransferRenameBuildEventData):
             return
-        source_path: Optional[str] = getattr(data, "source_path", None)
-        source_item: Optional[FileItem] = getattr(data, "source_item", None)
+        source_path: Optional[str] = data.source_path
+        source_item: Optional[FileItem] = data.source_item
         if not source_path or not str(source_path).strip():
             logger.debug("【媒体数据补充】source_path 为空，跳过本次重命名补全")
             return
@@ -1817,9 +1810,6 @@ class P115StrmHelper(_PluginBase):
         if Path(source_path).suffix.lower() not in settings.RMT_MEDIAEXT:
             logger.debug("【媒体数据补充】文件后缀不是媒体文件，跳过本次重命名补全")
             return
-
-        # 记录字段变更前的旧值快照：链式补丁路径下用于在上游已渲染串里定位被改字段
-        original_rename_dict: Dict[str, Any] = deepcopy(data.rename_dict)
 
         def share_strm_center(url: str) -> Optional[Dict[str, Any]]:
             for i in ["P115StrmHelper", "share_code=", "receive_code=", "id="]:
@@ -1849,7 +1839,6 @@ class P115StrmHelper(_PluginBase):
                 logger.warning(f"【媒体数据补充】{url} 中心化获取媒体信息失败: {e}")
                 return None
 
-        changed = False
         media_info: Dict[str, Any] = {}
 
         params: Dict[str, Any] = {"strm_resolve_media_info": share_strm_center}
@@ -1899,8 +1888,6 @@ class P115StrmHelper(_PluginBase):
         overwrite_mode = configer.rename_dict_supplement_overwrite_mode
         if overwrite_mode not in ("fill_missing", "always"):
             overwrite_mode = "fill_missing"
-        # 记录本次实际写入的字段，供链式补丁路径定位
-        applied_fields: Dict[str, Any] = {}
         for key, value in media_info.items():
             if not value:
                 continue
@@ -1909,90 +1896,6 @@ class P115StrmHelper(_PluginBase):
                 if cur is not None and not (isinstance(cur, str) and cur.strip() == ""):
                     continue
             data.rename_dict[key] = value
-            applied_fields[key] = value
-            changed = True
-        if not changed:
-            return
-
-        upstream_updated = bool(data.updated and data.updated_str)
-        if upstream_updated:
-            # 上游已写过 updated_str：基于其结果做差量补丁，避免重渲覆盖上游字符串级改动
-            new_render = self.__apply_rename_dict_patch_to_string(
-                base_str=data.updated_str,
-                original_rename_dict=original_rename_dict,
-                applied_fields=applied_fields,
-                upstream_source=data.source,
-            )
-            if new_render == data.updated_str:
-                # 没能定位到任何替换锚点，链式补丁未生效；不覆盖上游结果
-                logger.debug(
-                    "【媒体数据补充】上游已写入 updated_str 且本次补充字段在串中无锚点，"
-                    "保留上游结果不变（上游来源：%s）",
-                    data.source,
-                )
-                return
-        else:
-            # 没有上游写入：按原逻辑用 template_string 整体重渲
-            try:
-                new_render = Template(data.template_string).render(data.rename_dict)
-            except Exception as e:
-                logger.error(
-                    "【媒体数据补充】模板重新渲染失败: %s",
-                    e,
-                    exc_info=True,
-                )
-                return
-
-        data.updated = True
-        data.updated_str = new_render
-        data.source = "媒体数据补充"
-
-    @staticmethod
-    def __apply_rename_dict_patch_to_string(
-        base_str: str,
-        original_rename_dict: Dict[str, Any],
-        applied_fields: Dict[str, Any],
-        upstream_source: Optional[str] = None,
-    ) -> str:
-        """
-        在上游已渲染串上做单词边界级差量替换，避免链式覆盖。
-
-        仅对"旧值非空"的字段尝试 ``old_value -> new_value`` 替换；新增字段
-        （旧值为空）无法在已渲染串里定位锚点，本方法不会强行插入。
-
-        :param base_str: 上游写入的 ``updated_str``，作为替换基础。
-        :param original_rename_dict: 本插件改写 ``rename_dict`` 前的字段快照。
-        :param applied_fields: 本次实际改写的字段及其新值。
-        :param upstream_source: 上游处理器名称，仅用于日志。
-        :return: 应用差量替换后的字符串；若无可应用项则原样返回。
-        """
-        patched = base_str
-        skipped: List[str] = []
-        for key, new_value in applied_fields.items():
-            old_value = original_rename_dict.get(key)
-            if old_value is None or (
-                isinstance(old_value, str) and not old_value.strip()
-            ):
-                skipped.append(key)
-                continue
-            old_token = str(old_value)
-            new_token = str(new_value)
-            if old_token == new_token:
-                continue
-            # 单词边界替换，避免误伤同名子串（例如 audioCodec=AAC 不应替换文件名中的随机 "AAC" 子串）
-            pattern = rf"(?<![A-Za-z0-9]){re_escape(old_token)}(?![A-Za-z0-9])"
-            new_patched, count = re_subn(pattern, new_token, patched)
-            if count:
-                patched = new_patched
-            else:
-                skipped.append(key)
-        if skipped:
-            logger.debug(
-                "【媒体数据补充】链式补丁跳过字段 %s（上游来源：%s）",
-                ",".join(skipped),
-                upstream_source,
-            )
-        return patched
 
     @eventmanager.register(ChainEventType.TransferIntercept)
     def intercept_if_exists_in_library(self, event: Event) -> None:


### PR DESCRIPTION
## 背景

上游 MP 在 [jxxghp/MoviePilot#5792](https://github.com/jxxghp/MoviePilot/pull/5792) 引入了新的 `ChainEventType.TransferRenameBuild` 事件：在主程序首次 `Template.render` 之前发出，专门给插件一次往 `rename_dict` 写字段的机会。这条事件与原有的 `TransferRename`（渲染后字符串改写链）分层清晰：

- `TransferRenameBuild`：渲染前的"字段贡献"阶段，本两款插件应当落在这一阶段；
- `TransferRename`：渲染后的"字符串改写"阶段，由智能重命名、词替换、自定义模板等字符串改写类插件继续使用。

之前 #345 / #349 在旧事件上做的优先级排序、`updated_str` 差量补丁、`re.subn` 单词边界替换等"绕路"逻辑，都是为了在同一事件上和字符串改写类插件共存。新事件落地后这些绕路全部不再需要，本 PR 把两款插件迁到新事件。

## 改动

### `p115strmhelper.rename_dict_supplement`

- 注册改为 `@eventmanager.register(ChainEventType.TransferRenameBuild)`，去掉 `priority=5`（无需在同事件内抢序）。
- 事件数据类型从 `TransferRenameEventData` 换成 `TransferRenameBuildEventData`，直接读取属性（`data.source_path` / `data.source_item`），不再用 `getattr`。
- 删除 `__apply_rename_dict_patch_to_string` 静态方法（差量替换工具）以及调用它的 `upstream_updated` 分支：渲染前事件不存在"上游已渲染串"的语义。
- 删除 `Template(data.template_string).render(...)` 重渲分支：本插件不再负责渲染，只往 `rename_dict` 写字段即可。
- 删除 `data.updated / data.updated_str / data.source` 写回：新事件没有这些字段。
- 删除原 `rename_dict` 的 `deepcopy` 快照（差量补丁取消后不再需要）。
- 模块顶部对应清掉 `Template` / `re_escape` / `re_subn` 三处 import；`deepcopy` 仍被插件内其它路径使用，保留。

### `ffprobenamingsupplement.on_transfer_rename` → `on_transfer_rename_build`

- 方法重命名为 `on_transfer_rename_build`，更直观反映新事件名。
- 注册改为 `@eventmanager.register(ChainEventType.TransferRenameBuild)`，去掉 `priority=6`。
- 事件数据类型切换、直接属性读取，与上文一致。
- 删除"上游差量补丁 / 重渲整串 / 写回 updated_str"整段，仅保留 ffprobe 探测 + `_should_apply_key` 字段写入。
- 模块顶部清掉 `deepcopy / Template / re_escape / re_subn / TransferRenameEventData` 共 5 处 import。

### 不动的部分

- 配置项、表单、运行时缓存（`pantransfercacher` / `sharestrmcacher` / `_probe_cache`）、`_should_apply_key` 等辅助逻辑保持原样。
- 版本号未变（`version.py` / `package.v2.json`），由维护者发版时统一处理。

## 行为变化

- 两款插件迁入新事件后**不再依赖事件优先级**：渲染前事件上一般只有字段贡献类插件，互相之间用 `fill_missing` / `always` 两种 mode 自然处理同字段冲突即可。
- 与智能重命名（仍挂在 `TransferRename` 上）的关系彻底解耦：字段补充先写入 `rename_dict`，主程序渲染时已经含 SDR / H265 等字段，智能重命名再做大小写、词替换、模板覆盖。
- 渲染只发生一次（主程序首次 render），不再有"插件 ffprobe 后重渲整串"这条路径，整体快一些且更可预测。

## 兼容性

- **本 PR 不向后兼容旧版 MP**：模块加载时直接引用 `ChainEventType.TransferRenameBuild` 与 `TransferRenameBuildEventData`，缺少这两个符号的 MP 版本上插件会报 `ImportError` / `AttributeError`。
- 需要主程序合并 [jxxghp/MoviePilot#5792](https://github.com/jxxghp/MoviePilot/pull/5792) 并发版后用户才能升级。

## 验证

- `python3 -m py_compile plugins.v2/p115strmhelper/__init__.py plugins.v2/ffprobenamingsupplement/__init__.py` 通过。
- 全仓 grep 残留：`TransferRenameEventData` / `re_escape` / `re_subn` / `getattr(data, "source_*")` 均已清干净。
- 行为推演：
  - 仅启用本插件：MP 在 `get_rename_path` 发 `TransferRenameBuild`，插件写入 `effect=SDR` 等字段；主程序首次 `Template.render` 直接产出含 SDR 的文件名；行为等价于旧路径"补字段→重渲"。
  - 同时启用智能重命名：本插件在新事件写完字段后，主程序渲染 → 智能重命名在 `TransferRename` 上承接做词替换；最终落盘同时包含 SDR 和 `WEB-DL → Web-DL / x264 → H.264` 等改写。
  - 同时启用 p115 + ffprobe：两者都在新事件上注册，按插件加载先后顺序跑；`fill_missing` 模式下后跑者看到已填字段直接跳过；`always` 模式下后跑者覆盖前跑者，行为与 mode 含义一致。

Refs DDSRem-Dev/MoviePilot-Plugins#344
Refs InfinityPacer/MoviePilot-Plugins#180
Refs jxxghp/MoviePilot#5792

本 PR 为 Claude Code 协作提交。