### PR TITLE
feat(ffprobenamingsupplement,p115strmhelper): add videoBit rename template variable

### DIFF
--- a/frontend/p115strmhelper/src/components/sections/SystemConfigSection.vue
+++ b/frontend/p115strmhelper/src/components/sections/SystemConfigSection.vue
@@ -119,7 +119,7 @@
                 { title: '仅补全缺失或空值', value: 'fill_missing' },
                 { title: '始终用探测结果覆盖上述键', value: 'always' },
               ]" density="compact" color="info" :disabled="!config.rename_dict_supplement_enabled"
-                hint="针对 videoFormat、videoCodec、audioCodec、fps、effect 等：仅补全＝缺或空才写入；始终覆盖＝以 ffprobe/中心化结果为准覆盖"
+                hint="针对 videoFormat、videoCodec、videoBit、audioCodec、fps、effect 等：仅补全＝缺或空才写入；始终覆盖＝以 ffprobe/中心化结果为准覆盖"
                 persistent-hint></v-select>
             </v-col>
           </v-row>

--- a/package.v2.json
+++ b/package.v2.json
@@ -657,7 +657,7 @@
     },
     "FFprobeNamingSupplement": {
         "name": "ffprobe命名补充",
-        "description": "整理重命名时调用 ffprobe，补全命名模板中的 videoFormat、videoCodec、audioCodec、fps、effect，支持 STRM",
+        "description": "整理重命名时调用 ffprobe，补全命名模板中的 videoFormat、videoCodec、videoBit、audioCodec、fps、effect，支持 STRM",
         "labels": "整理",
         "version": "0.1.6",
         "icon": "https://raw.githubusercontent.com/jxxghp/MoviePilot-Plugins/refs/heads/main/icons/ffmpeg.png",

--- a/plugins.v2/ffprobenamingsupplement/__init__.py
+++ b/plugins.v2/ffprobenamingsupplement/__init__.py
@@ -1,5 +1,6 @@
 from json import JSONDecodeError, loads
 from pathlib import Path
+from re import IGNORECASE, search as re_search
 from subprocess import TimeoutExpired, run
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote
@@ -19,7 +20,7 @@ class FFprobeNamingSupplement(_PluginBase):
     """
 
     plugin_name = "ffprobe命名补充"
-    plugin_desc = "整理重命名时调用 ffprobe，补全命名模板中的 videoFormat、videoCodec、audioCodec、fps、effect，支持 STRM "
+    plugin_desc = "整理重命名时调用 ffprobe，补全命名模板中的 videoFormat、videoCodec、videoBit、audioCodec、fps、effect，支持 STRM "
     plugin_icon = "https://raw.githubusercontent.com/jxxghp/MoviePilot-Plugins/refs/heads/main/icons/ffmpeg.png"
     plugin_version = "0.1.6"
     plugin_author = "DDSRem"
@@ -207,7 +208,7 @@ class FFprobeNamingSupplement(_PluginBase):
                                             "label": "写入策略",
                                             "items": overwrite_items,
                                             "hint": (
-                                                "针对 videoFormat、videoCodec、audioCodec、fps、effect："
+                                                "针对 videoFormat、videoCodec、videoBit、audioCodec、fps、effect："
                                                 "仅补全＝缺或空才写入；始终覆盖＝以 ffprobe 为准覆盖"
                                             ),
                                             "persistent-hint": True,
@@ -278,6 +279,13 @@ class FFprobeNamingSupplement(_PluginBase):
                                                     "class": "text-body-2 mt-1",
                                                 },
                                                 "text": "{{videoCodec}} — 视频编码（如 H264、H265）",
+                                            },
+                                            {
+                                                "component": "div",
+                                                "props": {
+                                                    "class": "text-body-2 mt-1",
+                                                },
+                                                "text": "{{videoBit}} — 视频位深（如 8bit、10bit）",
                                             },
                                             {
                                                 "component": "div",
@@ -622,6 +630,26 @@ class FFprobeNamingSupplement(_PluginBase):
         return video_s, audio_s
 
     @classmethod
+    def _extract_video_bit_depth(cls, video_s: Dict[str, Any]) -> Optional[str]:
+        """从 ffprobe 视频流提取位深，如 8bit、10bit"""
+        bps = (video_s.get("bits_per_raw_sample") or "").strip()
+        if bps and bps.isdigit():
+            return f"{bps}bit"
+        pix = (video_s.get("pix_fmt") or "").strip().lower()
+        if pix:
+            m = re_search(r"(\d+)(le|be)", pix)
+            if m:
+                n = int(m.group(1))
+                if n > 0:
+                    return f"{n}bit"
+        prof = (video_s.get("profile") or "").strip()
+        if prof:
+            m = re_search(r"main\s*(\d+)", prof, IGNORECASE)
+            if m:
+                return f"{m.group(1)}bit"
+        return None
+
+    @classmethod
     def _probe_to_rename_fields(cls, probe_json: Dict[str, Any]) -> Dict[str, str]:
         """
         从 ffprobe JSON 提取写入 rename_dict 的命名模板字段
@@ -648,6 +676,9 @@ class FFprobeNamingSupplement(_PluginBase):
             vc = cls._map_video_codec(video_s.get("codec_name"))
             if vc:
                 out["videoCodec"] = vc
+            vb = cls._extract_video_bit_depth(video_s)
+            if vb:
+                out["videoBit"] = vb
             fps = cls._parse_frame_rate(
                 video_s.get("avg_frame_rate")
             ) or cls._parse_frame_rate(video_s.get("r_frame_rate"))

--- a/plugins.v2/p115strmhelper/utils/rename_dict.py
+++ b/plugins.v2/p115strmhelper/utils/rename_dict.py
@@ -1,5 +1,6 @@
 __all__ = ["RenameDictUtils"]
 
+from re import IGNORECASE, search as re_search
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from pathlib import Path
 from urllib.parse import unquote
@@ -409,6 +410,26 @@ class RenameDictUtils:
         return video_s, audio_s
 
     @staticmethod
+    def _extract_video_bit_depth(video_s: Dict[str, Any]) -> Optional[str]:
+        """从 ffprobe 视频流提取位深，如 8bit、10bit"""
+        bps = (video_s.get("bits_per_raw_sample") or "").strip()
+        if bps and bps.isdigit():
+            return f"{bps}bit"
+        pix = (video_s.get("pix_fmt") or "").strip().lower()
+        if pix:
+            m = re_search(r"(\d+)(le|be)", pix)
+            if m:
+                n = int(m.group(1))
+                if n > 0:
+                    return f"{n}bit"
+        prof = (video_s.get("profile") or "").strip()
+        if prof:
+            m = re_search(r"main\s*(\d+)", prof, IGNORECASE)
+            if m:
+                return f"{m.group(1)}bit"
+        return None
+
+    @staticmethod
     def _probe_to_rename_fields(probe_json: Dict[str, Any]) -> Dict[str, str]:
         """
         从 ffprobe JSON 提取写入 rename_dict 的命名模板字段
@@ -435,6 +456,9 @@ class RenameDictUtils:
             vc = RenameDictUtils._map_video_codec(video_s.get("codec_name"))
             if vc:
                 out["videoCodec"] = vc
+            vb = RenameDictUtils._extract_video_bit_depth(video_s)
+            if vb:
+                out["videoBit"] = vb
             fps = RenameDictUtils._parse_frame_rate(
                 video_s.get("avg_frame_rate")
             ) or RenameDictUtils._parse_frame_rate(video_s.get("r_frame_rate"))
@@ -700,7 +724,7 @@ class RenameDictUtils:
         从 Emby 媒体信息 JSON 提取写入 rename_dict 的命名模板字段
 
         输出键与 RenameDictUtils._probe_to_rename_fields 一致：
-        videoFormat、videoCodec、fps、effect、audioCodec（有则写入）
+        videoFormat、videoCodec、videoBit、fps、effect、audioCodec（有则写入）
 
         :param payload: download_emby_mediainfo_data 单条值，或含 MediaSourceInfo 的 list/dict
         :return: 字符串字典，无法解析时为空 dict
@@ -727,6 +751,12 @@ class RenameDictUtils:
             vc = RenameDictUtils._map_video_codec(video_s.get("Codec"))
             if vc:
                 out["videoCodec"] = vc
+            vb = video_s.get("BitDepth")
+            if vb:
+                try:
+                    out["videoBit"] = f"{int(vb)}bit"
+                except (TypeError, ValueError):
+                    pass
             fps = RenameDictUtils._emby_numeric_fps_to_str(
                 video_s.get("AverageFrameRate")
             ) or RenameDictUtils._emby_numeric_fps_to_str(video_s.get("RealFrameRate"))


### PR DESCRIPTION
Extract bit depth from ffprobe (bits_per_raw_sample / pix_fmt / profile) and Emby (BitDepth), output as "8bit" / "10bit" for {{videoBit}}.