### PR TITLE
fix(ffprobenamingsupplement, p115strmhelper): add 8bit fallback for video bit depth extraction

### DIFF
--- a/plugins.v2/ffprobenamingsupplement/__init__.py
+++ b/plugins.v2/ffprobenamingsupplement/__init__.py
@@ -652,6 +652,8 @@ class FFprobeNamingSupplement(_PluginBase):
             m = re_search(r"(?:main|high)\s*(\d+)", prof, IGNORECASE)
             if m:
                 return f"{m.group(1)}bit"
+        if pix:
+            return "8bit"
         return None
 
     @classmethod

--- a/plugins.v2/p115strmhelper/utils/rename_dict.py
+++ b/plugins.v2/p115strmhelper/utils/rename_dict.py
@@ -432,6 +432,8 @@ class RenameDictUtils:
             m = re_search(r"(?:main|high)\s*(\d+)", prof, IGNORECASE)
             if m:
                 return f"{m.group(1)}bit"
+        if pix:
+            return "8bit"
         return None
 
     @staticmethod


### PR DESCRIPTION
标准 8-bit HEVC 视频（yuv420p + Main profile）无法提取 videoBit，因为 _extract_video_bit_depth 的三级回退都依赖编码器显式声明的位深标识，对于默认 8-bit 编码全部无法命中。

测试视频 ffprobe 数据（video stream）

1.mp4
```json
{
    "codec_name": "hevc",
    "codec_long_name": "H.265 / HEVC (High Efficiency Video Coding)",
    "profile": "Main",
    "codec_type": "video",
    "width": 3840,
    "height": 1608,
    "pix_fmt": "yuv420p",
    "level": 150,
    "r_frame_rate": "25/1",
    "avg_frame_rate": "25/1",
    "bit_rate": "5295580",
    "tags": {
        "language": "und",
        "handler_name": "VideoHandler"
    }
}
```

2.mp4
```json
{
    "codec_name": "hevc",
    "codec_long_name": "H.265 / HEVC (High Efficiency Video Coding)",
    "profile": "Main",
    "codec_type": "video",
    "width": 3840,
    "height": 1632,
    "pix_fmt": "yuv420p",
    "level": 150,
    "r_frame_rate": "25/1",
    "avg_frame_rate": "25/1",
    "bit_rate": "4716394",
    "tags": {
        "language": "und",
        "handler_name": "VideoHandler"
    }
}
```