### PR TITLE
fix(ffprobenamingsupplement,p115strmhelper): overwrite audioCodec if channels tags are missing

### DIFF
--- a/plugins.v2/ffprobenamingsupplement/__init__.py
+++ b/plugins.v2/ffprobenamingsupplement/__init__.py
@@ -760,8 +760,12 @@ class FFprobeNamingSupplement(_PluginBase):
         cur = rename_dict.get(key)
         if cur is None:
             return True
-        if isinstance(cur, str) and cur.strip() == "":
-            return True
+        if isinstance(cur, str):
+            cur_stripped = cur.strip()
+            if not cur_stripped:
+                return True
+            if key == "audioCodec" and not re_search(r"\d+\.\d+", cur_stripped):
+                return True
         return False
 
     @classmethod

--- a/plugins.v2/p115strmhelper/__init__.py
+++ b/plugins.v2/p115strmhelper/__init__.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from dataclasses import asdict
 from functools import wraps
 from pathlib import Path
+from re import search as re_search
 from typing import Any, List, Dict, Tuple, Optional, Union
 
 from app.core.config import settings
@@ -1936,7 +1937,13 @@ class P115StrmHelper(_PluginBase):
                 continue
             if overwrite_mode == "fill_missing":
                 cur = data.rename_dict.get(key)
-                if cur is not None and not (isinstance(cur, str) and cur.strip() == ""):
+                if cur is None:
+                    pass
+                elif isinstance(cur, str):
+                    cur_stripped = cur.strip()
+                    if cur_stripped and (key != "audioCodec" or re_search(r"\d+\.\d+", cur_stripped)):
+                        continue
+                else:
                     continue
             data.rename_dict[key] = value
 


### PR DESCRIPTION
在“仅补全缺失或空值”模式下，原判定逻辑会导致仅含基础编码而无声道信息的 audioCodec（如 "AAC"）因值不为空而被跳过补全，现修复后在缺失声道信息的情况下允许被 ffprobe 探测到的完整数据（如 "AAC 2.0"）正常覆盖写入