### PR TITLE
fix(p115strmhelper): filter HDHive resource responses

### DIFF
--- a/plugins.v2/p115strmhelper/helper/hdhive/browser.py
+++ b/plugins.v2/p115strmhelper/helper/hdhive/browser.py
@@ -32,6 +32,7 @@ from orjson import dumps, loads
 from app.core.config import settings
 
 from ...core.config import configer
+from ...utils.hdhive import extract_hdhive_resource_rows
 from ...utils.sentry import sentry_manager
 
 _CLOAKBROWSER_AVAILABLE = False
@@ -2038,27 +2039,7 @@ class HDHivePlaywrightClient:
                     if "json" not in response.headers.get("content-type", ""):
                         return
                     body = response.json()
-                    if not isinstance(body, dict):
-                        return
-                    data = body.get("data")
-                    if not isinstance(data, list) or not data:
-                        return
-                    first = data[0]
-                    if not isinstance(first, dict):
-                        return
-                    if any(
-                        k in first
-                        for k in (
-                            "size",
-                            "resolution",
-                            "video_resolution",
-                            "share_size",
-                            "source",
-                            "slug",
-                            "unlock_points",
-                        )
-                    ):
-                        captured.extend(data)
+                    captured.extend(extract_hdhive_resource_rows(body))
                 except Exception:
                     pass
 

--- a/plugins.v2/p115strmhelper/tests/test_hdhive_browser.py
+++ b/plugins.v2/p115strmhelper/tests/test_hdhive_browser.py
@@ -1,0 +1,50 @@
+"""
+HDHive 浏览器资源响应测试模块
+"""
+
+from unittest import TestCase
+
+from utils.hdhive import extract_hdhive_resource_rows
+
+
+class TestExtractHDHiveResourceRows(TestCase):
+    """测试 HDHive 资源响应筛选"""
+
+    def test_ignores_unrelated_rows_with_source_field(self):
+        """测试忽略含 source 字段的非资源列表"""
+        body = {
+            "data": [
+                {
+                    "name": "unrelated entry",
+                    "source": "account",
+                }
+            ]
+        }
+
+        self.assertEqual(extract_hdhive_resource_rows(body), [])
+
+    def test_keeps_rows_with_resource_href(self):
+        """测试保留带资源详情链接的条目"""
+        resource = {
+            "title": "resource entry",
+            "href": "/resource/115/example-slug",
+        }
+        body = {"data": [resource]}
+
+        self.assertEqual(extract_hdhive_resource_rows(body), [resource])
+
+    def test_filters_mixed_response_rows(self):
+        """测试混合响应中仅保留资源条目"""
+        resource = {
+            "title": "resource entry",
+            "href": "https://hdhive.com/resource/115/example-slug",
+        }
+        body = {
+            "data": [
+                {"source": "account"},
+                resource,
+                "invalid row",
+            ]
+        }
+
+        self.assertEqual(extract_hdhive_resource_rows(body), [resource])

--- a/plugins.v2/p115strmhelper/utils/hdhive.py
+++ b/plugins.v2/p115strmhelper/utils/hdhive.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict, List
+
+
+def extract_hdhive_resource_rows(body: Any) -> List[Dict[str, Any]]:
+    """
+    从 HDHive JSON 响应中筛出带资源详情链接的条目
+
+    :param body (Any): JSON 响应体
+
+    :return List: 可供资源搜索消费的资源条目
+    """
+    if not isinstance(body, dict):
+        return []
+    data = body.get("data")
+    if not isinstance(data, list):
+        return []
+    return [
+        row
+        for row in data
+        if isinstance(row, dict)
+        and "/resource/" in str(row.get("href") or "")
+    ]


### PR DESCRIPTION
## Summary

- ignore unrelated HDHive JSON lists that happen to contain fields such as `source`
- only capture rows with a `/resource/` detail link before falling back to DOM scraping
- add regression coverage for unrelated, valid, and mixed response payloads

## Root cause

The response listener treated the first JSON list containing any broad resource-like field as the resource result. An unrelated account list containing `source` could arrive first, short-circuit the wait, and return rows without `href`. The downstream search mapper then discarded every row and displayed page 1 / 0.

## Verification

- `PYTHONPATH=plugins.v2/p115strmhelper python3 -m unittest discover -s plugins.v2/p115strmhelper/tests -p "test_hdhive_browser.py" -v`
- live HDHive lookup for movie TMDB 535167 returned 8 rows, all with `/resource/` links

No resource was unlocked during verification.