### PR TITLE
ci: 完善 P115StrmHelper Python 3.14 原生构建矩阵

### DIFF
--- a/.github/workflows/rust_build_full_sync_strm.yml
+++ b/.github/workflows/rust_build_full_sync_strm.yml
@@ -4,20 +4,70 @@ on:
   workflow_dispatch:
 
 jobs:
+  extension_tests:
+    name: full_strm_sync import test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.12', '3.14']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build and install full_strm_sync
+        working-directory: plugins.v2/p115strmhelper/rust_utils/full_strm_sync/
+        run: python -m pip install .
+
+      - name: Verify import
+        run: python -c "import full_strm_sync; print(full_strm_sync.__version__)"
+
   build_wheels:
-    name: Build wheels for ${{ matrix.target }} on ${{ matrix.os }}
+    name: Build wheels for Python ${{ matrix.python-version }} / ${{ matrix.target }} on ${{ matrix.os }}
+    needs: [extension_tests]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.14'
           - os: windows-latest
+            python-version: '3.12'
+          - os: windows-latest
+            python-version: '3.14'
           - os: macos-latest
+            python-version: '3.12'
+          - os: macos-latest
+            python-version: '3.14'
+          - os: macos-latest
+            python-version: '3.12'
             target: universal2-apple-darwin
           - os: macos-15
+            python-version: '3.12'
             target: x86_64-apple-darwin
           - os: ubuntu-latest
+            python-version: '3.12'
+            target: aarch64
+          - os: macos-latest
+            python-version: '3.14'
+            target: universal2-apple-darwin
+          - os: macos-15
+            python-version: '3.14'
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            python-version: '3.14'
             target: aarch64
 
     steps:
@@ -34,14 +84,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/full_strm_sync/
 
@@ -51,7 +101,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-musl
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/full_strm_sync/
 
@@ -61,14 +111,14 @@ jobs:
         with:
           target: aarch64-unknown-linux-musl
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/full_strm_sync/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.target }}
+          name: wheels-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.target }}
           path: plugins.v2/p115strmhelper/rust_utils/full_strm_sync/dist
 
   commit_wheels:
@@ -104,4 +154,3 @@ jobs:
             git push
             echo "新的 wheel 文件已成功提交并推送。"
           fi
-

--- a/.github/workflows/rust_build_share_strm_scan.yml
+++ b/.github/workflows/rust_build_share_strm_scan.yml
@@ -5,12 +5,13 @@ on:
 
 jobs:
   extension_tests:
-    name: share_strm_scan unittest on ${{ matrix.os }}
+    name: share_strm_scan unittest on ${{ matrix.os }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.12', '3.14']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -21,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Build and install share_strm_scan
         working-directory: plugins.v2/p115strmhelper/rust_utils/share_strm_scan/
@@ -32,7 +33,7 @@ jobs:
         run: python -m unittest discover -s tests -v
 
   build_wheels:
-    name: Build wheels for ${{ matrix.target }} on ${{ matrix.os }}
+    name: Build wheels for Python ${{ matrix.python-version }} / ${{ matrix.target }} on ${{ matrix.os }}
     needs: [extension_tests]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -40,12 +41,34 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.14'
           - os: windows-latest
+            python-version: '3.12'
+          - os: windows-latest
+            python-version: '3.14'
           - os: macos-latest
+            python-version: '3.12'
+          - os: macos-latest
+            python-version: '3.14'
+          - os: macos-latest
+            python-version: '3.12'
             target: universal2-apple-darwin
           - os: macos-15
+            python-version: '3.12'
             target: x86_64-apple-darwin
           - os: ubuntu-latest
+            python-version: '3.12'
+            target: aarch64
+          - os: macos-latest
+            python-version: '3.14'
+            target: universal2-apple-darwin
+          - os: macos-15
+            python-version: '3.14'
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            python-version: '3.14'
             target: aarch64
 
     steps:
@@ -62,14 +85,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/share_strm_scan/
 
@@ -79,7 +102,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-musl
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/share_strm_scan/
 
@@ -89,14 +112,14 @@ jobs:
         with:
           target: aarch64-unknown-linux-musl
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/share_strm_scan/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-share-strm-scan-${{ matrix.os }}-${{ matrix.target }}
+          name: wheels-share-strm-scan-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.target }}
           path: plugins.v2/p115strmhelper/rust_utils/share_strm_scan/dist
 
   commit_wheels:

--- a/.github/workflows/rust_build_txt_tree_storage.yml
+++ b/.github/workflows/rust_build_txt_tree_storage.yml
@@ -5,12 +5,13 @@ on:
 
 jobs:
   parity_test:
-    name: Parity test (Python vs Rust) on ${{ matrix.os }}
+    name: Parity test (Python vs Rust) on ${{ matrix.os }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.12', '3.14']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -21,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install pytest
         run: pip install pytest
@@ -35,7 +36,7 @@ jobs:
         run: pytest tests/test_parity.py -v
 
   build_wheels:
-    name: Build wheels for ${{ matrix.target }} on ${{ matrix.os }}
+    name: Build wheels for Python ${{ matrix.python-version }} / ${{ matrix.target }} on ${{ matrix.os }}
     needs: [parity_test]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -43,12 +44,34 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.14'
           - os: windows-latest
+            python-version: '3.12'
+          - os: windows-latest
+            python-version: '3.14'
           - os: macos-latest
+            python-version: '3.12'
+          - os: macos-latest
+            python-version: '3.14'
+          - os: macos-latest
+            python-version: '3.12'
             target: universal2-apple-darwin
           - os: macos-15
+            python-version: '3.12'
             target: x86_64-apple-darwin
           - os: ubuntu-latest
+            python-version: '3.12'
+            target: aarch64
+          - os: macos-latest
+            python-version: '3.14'
+            target: universal2-apple-darwin
+          - os: macos-15
+            python-version: '3.14'
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            python-version: '3.14'
             target: aarch64
 
     steps:
@@ -65,14 +88,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/txt_tree_storage/
 
@@ -82,7 +105,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-musl
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/txt_tree_storage/
 
@@ -92,14 +115,14 @@ jobs:
         with:
           target: aarch64-unknown-linux-musl
           command: build
-          args: --release --out dist -i python3.12
+          args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: auto
           working-directory: plugins.v2/p115strmhelper/rust_utils/txt_tree_storage/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-txt-${{ matrix.os }}-${{ matrix.target }}
+          name: wheels-txt-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.target }}
           path: plugins.v2/p115strmhelper/rust_utils/txt_tree_storage/dist
 
   commit_wheels:

--- a/.github/workflows/test-p115strmhelper.yml
+++ b/.github/workflows/test-p115strmhelper.yml
@@ -20,6 +20,8 @@ on:
       # utils (test_tree.py)
       - 'plugins.v2/p115strmhelper/utils/tree.py'
       - 'plugins.v2/p115strmhelper/tests/**'
+      - 'plugins.v2/p115strmhelper/requirements.txt'
+      - 'plugins.v2/p115strmhelper/rust_utils/**'
       - '.github/workflows/test-p115strmhelper.yml'
   pull_request:
     paths:
@@ -40,14 +42,25 @@ on:
       # utils (test_tree.py)
       - 'plugins.v2/p115strmhelper/utils/tree.py'
       - 'plugins.v2/p115strmhelper/tests/**'
+      - 'plugins.v2/p115strmhelper/requirements.txt'
+      - 'plugins.v2/p115strmhelper/rust_utils/**'
       - '.github/workflows/test-p115strmhelper.yml'
   workflow_dispatch:
 
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.14'
+          - os: windows-latest
+            python-version: '3.12'
+          - os: windows-latest
+            python-version: '3.14'
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -67,10 +80,13 @@ jobs:
           repository: jxxghp/MoviePilot-Resources
           path: MoviePilot-Resources
 
-      - name: Set up Python 3.12
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: |
             MoviePilot/requirements.txt
@@ -80,10 +96,20 @@ jobs:
         run: |
           python -c "from pathlib import Path; from shutil import copy2; src = Path('MoviePilot-Resources/resources.v2'); dst = Path('MoviePilot/app/helper'); dst.mkdir(parents=True, exist_ok=True); [copy2(p, dst / p.name) for p in src.iterdir() if p.is_file()]"
 
+      - name: Build native dependencies for tests
+        run: |
+          python -m pip wheel --no-deps --wheel-dir plugins.v2/p115strmhelper/wheels plugins.v2/p115strmhelper/rust_utils/full_strm_sync plugins.v2/p115strmhelper/rust_utils/txt_tree_storage plugins.v2/p115strmhelper/rust_utils/share_strm_scan
+          python -m pip download --no-deps --only-binary=:all: --dest plugins.v2/p115strmhelper/wheels "pyahocorasick~=2.3.0"
+
       - name: Install dependencies
         run: |
-          pip install -r MoviePilot/requirements.txt
-          pip install --find-links plugins.v2/p115strmhelper/wheels -r plugins.v2/p115strmhelper/requirements.txt
+          python -m pip install --no-index --find-links plugins.v2/p115strmhelper/wheels full_strm_sync==0.1.6 txt_tree_storage==0.2.1 share_strm_scan==0.2.2 pyahocorasick~=2.3.0
+          python -m pip install -r MoviePilot/requirements.txt
+          python -m pip install --find-links plugins.v2/p115strmhelper/wheels -r plugins.v2/p115strmhelper/requirements.txt
+
+      - name: Verify bundled native imports
+        run: |
+          python -c "import full_strm_sync; import share_strm_scan; import txt_tree_storage; import ahocorasick"
 
       - name: Start Redis (Ubuntu)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## 目的

补齐 P115StrmHelper 三个 Rust 扩展在 Python 3.14 下的跨平台构建与测试能力。当前 PR 仅调整 CI，不更新插件版本、不提交 wheel，也不触发发版。

## 改动

- Rust 构建工作流覆盖 Python 3.12/3.14 及 Linux、Windows、macOS、musllinux 和 ARM 目标，并按 Python 版本区分构建制品。
- P115StrmHelper 测试工作流覆盖 Ubuntu/Windows 的 Python 3.12/3.14。
- 测试任务在 CI 中从 rust_utils 临时构建原生 wheel，并使用本地制品完成导入和插件测试；这些临时制品不会进入仓库。

正式 wheel 生成和插件版本发布另行处理。

## 验证

- 四个工作流 YAML 解析通过。
- git diff --check 通过。
- 本地 full_strm_sync wheel 构建通过。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 8aa8de00532238117c4927c4c5e69d2e3225c2fa

- 将三个 Rust 扩展的构建矩阵扩展至 Python 3.12/3.14，覆盖 Linux、Windows、macOS、musllinux 与 ARM 目标
- 新增 full_strm_sync 跨平台导入测试，并让 share_strm_scan、txt_tree_storage 在 Python 3.14 下运行测试
- 测试工作流增加 Python 3.14 与 Rust 工具链，通过本地临时 wheel 构建安装原生依赖并验证导入
- 构建与测试任务按 Python 版本区分产物，避免覆盖，同时禁用 fail-fast 提升矩阵稳定性
- 仅调整 CI，不更新插件版本、不提交正式 wheel，不引入运行时兼容性变化
<!-- pr-agent-summary:end -->
