### PR TITLE
fix(p115strmhelper): 增量清理跳过目录路径

### DIFF
--- a/plugins.v2/p115strmhelper/helper/strm/increment.py
+++ b/plugins.v2/p115strmhelper/helper/strm/increment.py
@@ -772,6 +772,10 @@ class IncrementSyncStrmHelper:
         """
         立即删除单个无效 STRM 文件
         """
+        # 扫描后路径可能变成目录，不能按文件删除或递归清理其内容
+        if Path(remove_path).is_dir():
+            logger.warning(f"【增量STRM生成】跳过目录路径: {remove_path}")
+            return
         logger.info(f"【增量STRM生成】清理无效 STRM 文件: {remove_path}")
         Path(remove_path).unlink(missing_ok=True)
         if self.remove_unless_file:

--- a/plugins.v2/p115strmhelper/tests/test_increment_cleanup.py
+++ b/plugins.v2/p115strmhelper/tests/test_increment_cleanup.py
@@ -1,0 +1,67 @@
+"""增量清理目录条目的回归测试"""
+
+import ast
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+
+def _load_cleanup():
+    # 仅加载实际清理方法，避免导入网盘客户端及 MoviePilot 运行时
+    source = Path(__file__).resolve().parents[1] / "helper/strm/increment.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "IncrementSyncStrmHelper"
+    )
+    method = next(
+        node for node in helper.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "__remove_unless_strm_path"
+    )
+    namespace = {"Path": Path, "logger": Mock(), "PathRemoveUtils": Mock()}
+    exec(compile(ast.Module(body=[method], type_ignores=[]), str(source), "exec"), namespace)
+    return namespace[method.name], namespace["PathRemoveUtils"]
+
+
+class TestIncrementCleanup(TestCase):
+    """验证目录不会中断文件清理或被递归删除"""
+
+    def test_directory_is_preserved_and_next_file_is_removed(self) -> None:
+        """无论空目录清理开关如何，目录内容均保留且不计入文件删除数"""
+        for remove_dirs in (False, True):
+            with self.subTest(remove_dirs=remove_dirs), TemporaryDirectory() as root:
+                cleanup, related = _load_cleanup()
+                helper = SimpleNamespace(
+                    remove_unless_dir=remove_dirs,
+                    remove_unless_file=True,
+                    remove_unless_strm_count=0,
+                )
+                directory = Path(root) / "changed.strm"
+                directory.mkdir()
+                child = directory / "keep.txt"
+                child.write_text("keep", encoding="utf-8")
+                cleanup(helper, str(directory))
+                self.assertEqual(child.read_text(encoding="utf-8"), "keep")
+                self.assertEqual(helper.remove_unless_strm_count, 0)
+                related.clean_related_files.assert_not_called()
+                related.remove_parent_dir.assert_not_called()
+                stale = Path(root) / "stale.strm"
+                stale.write_text("obsolete", encoding="utf-8")
+                cleanup(helper, str(stale))
+                self.assertFalse(stale.exists())
+                self.assertEqual(helper.remove_unless_strm_count, 1)
+                related.clean_related_files.assert_called_once()
+                self.assertEqual(related.remove_parent_dir.call_count, int(remove_dirs))
+
+    def test_permission_error_is_not_hidden(self) -> None:
+        """普通文件删除权限错误仍向调用方传播"""
+        cleanup, _ = _load_cleanup()
+        helper = SimpleNamespace(remove_unless_strm_count=0)
+        with patch.object(Path, "is_dir", return_value=False), patch.object(
+            Path, "unlink", side_effect=PermissionError("denied")
+        ), self.assertRaises(PermissionError):
+            cleanup(helper, "file.strm")
+        self.assertEqual(helper.remove_unless_strm_count, 0)


### PR DESCRIPTION
增量清理的差异列表预期包含文件，但扫描结束后对应路径可能已经变成目录。当前直接调用 `Path.unlink()` 会抛错，使本轮剩余无效文件清理中断。

此修改遇到目录时记录警告并跳过，不删除目录内容、不调用关联文件/父目录清理，也不增加文件删除计数。正常文件仍走原有清理流程。`remove_unless_dir` 的现有父目录清理语义保持不变，未引入递归删除行为。

验证：
- 新增回归测试在修改前可复现：目录清理开关开启、关闭两种情况均因 `unlink()` 目录失败；修改后通过。
- 确认目录内容保留、跳过不计数、后续普通文件继续清理，普通文件权限错误仍然传播。
- `python3 -m unittest discover -s plugins.v2/p115strmhelper/tests -p test_increment_cleanup.py`：2 个测试方法通过（目录用例包含开关两种子场景）。
- Python 语法检查及 `git diff --check` 通过。

测试通过 AST 从真实源码加载目标方法，在临时目录上执行，日志与关联清理 helper 使用 mock，避免依赖整个 MoviePilot/115 运行时；未运行网盘端到端测试。此次仅修改现有 `plugins.v2/p115strmhelper` 实现，不更改依赖、发布版本或其他个人定制代码。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 7e2a03a13d88cc9ccd95e95ae7bff79abaf3ad54

- 修复增量清理中扫描后路径变为目录时 `unlink()` 报错中断
- 遇到目录仅记录警告并跳过，不删除内容、不计数、不触发关联清理
- 新增回归测试覆盖目录保留、后续普通文件清理及权限错误传播
<!-- pr-agent-summary:end -->
