### PR TITLE
feat(V3): add PlexToolbox for STRM direct playback

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -170,6 +170,21 @@
             "v3.0.0": "适配 MoviePilot V3 SDK 与整理重命名事件契约"
         }
     },
+    "PlexToolbox": {
+        "name": "PLEX 工具箱",
+        "description": "Plex 302 反向代理、STRM 媒体信息补全、缺海报修复与重复条目合并；支持无 Emby 时用 ffprobe 探测 STRM 直链。",
+        "labels": "媒体,工具",
+        "version": "1.1.0",
+        "release": true,
+        "icon": "https://raw.githubusercontent.com/jxxghp/MoviePilot-Plugins/refs/heads/main/icons/Plex_A.png",
+        "author": "shyblacktea,MoviePilot助手",
+        "system_version": ">=3.0.0",
+        "level": 1,
+        "history": {
+            "v1.1.0": "新增无 Emby 时使用 ffprobe 探测 STRM 直链，并增加 Plex 主机到 MoviePilot 容器的路径映射",
+            "v1.0.0": "新增 Plex 302 反向代理、媒体信息补全、海报修复与重复条目合并"
+        }
+    },
     "P115SubFixer": {
         "name": "115订阅站点修复",
         "description": "修复115网盘订阅追更插件导致的订阅站点被篡改问题，并自动卸载该插件",

--- a/plugins.v3/plextoolbox/.gitignore
+++ b/plugins.v3/plextoolbox/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+__pycache__/
+*.pyc

--- a/plugins.v3/plextoolbox/__init__.py
+++ b/plugins.v3/plextoolbox/__init__.py
@@ -1,0 +1,944 @@
+"""PLEX 工具箱插件：Plex 302 反向代理 + STRM 媒体流信息补全。"""
+
+import json
+from threading import Lock, Thread
+from time import monotonic, time
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import Request
+from uvicorn import Config, Server
+
+from app.sdk.logging import logger
+from app.plugins import _PluginBase
+from app.schemas.types import EventType, NotificationType
+
+try:
+    from apscheduler.triggers.interval import IntervalTrigger
+except Exception:
+    IntervalTrigger = None
+
+from .proxy_app import create_app
+from .emby_client import EmbyClient
+from .ffprobe_source import FfprobeSource
+from .helper_client import HelperClient
+from .mediainfo import MediaInfoCompleter
+from .plex_client import PlexClient
+from .poster_fixer import PosterFixer
+from .scrape_tools import ScrapeTools
+
+
+PIN_RULES_SEP = " => "
+
+
+def _parse_pin_rules(raw: str) -> List[Tuple[str, str]]:
+    """
+    解析顶置路径规则字符串为 (路径前缀, 目标URL) 列表。
+
+    :param raw: 多行文本，每行「路径前缀 => 目标URL」
+    :return: 合法规则列表；非法行忽略并打日志
+    """
+    result: List[Tuple[str, str]] = []
+    for line in (raw or "").strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if PIN_RULES_SEP not in line:
+            logger.warning('顶置规则格式错误，已忽略: %s', line)
+            continue
+        parts = line.split(PIN_RULES_SEP, 1)
+        path_prefix = parts[0].strip()
+        target_url = parts[1].strip()
+        if not path_prefix or not target_url:
+            logger.warning("顶置规则路径或目标为空，已忽略: %s", line)
+            continue
+        if not target_url.startswith(("http://", "https://")):
+            logger.warning("顶置规则目标需以 http/https 开头，已忽略: %s", line)
+            continue
+        result.append((path_prefix, target_url))
+    return result
+
+
+class PlexToolbox(_PluginBase):
+    """PLEX 工具箱：302 反向代理与 STRM 媒体流信息补全。"""
+
+    plugin_name = "PLEX 工具箱"
+    plugin_desc = "Plex 302 反向代理、STRM 媒体流信息补全（支持无 Emby 的 ffprobe 数据源）、缺海报修复与 TMDB 重复条目合并。"
+    plugin_icon = "https://raw.githubusercontent.com/jxxghp/MoviePilot-Plugins/refs/heads/main/icons/Plex_A.png"
+    plugin_version = "1.1.0"
+    plugin_author = "shyblacktea,MoviePilot助手"
+    author_url = "https://github.com/shyblacktea"
+    plugin_config_prefix = "plextoolbox_"
+    plugin_order = 20
+    auth_level = 1
+
+    # ---- 反代配置 ----
+    _enabled = False
+    _proxy_enabled = False
+    _plex_host = ""
+    _plex_token = ""
+    _host = "0.0.0.0"
+    _port = 32401
+    _pin_rules: List[Tuple[str, str]] = []
+    _pin_rules_raw = ""
+    _force_direct_play = True
+    _server = None
+    _thread = None
+
+    # ---- 媒体信息补全配置 ----
+    _mediainfo_enabled = False
+    _plex_direct_host = ""
+    _helper_url = ""
+    _helper_token = ""
+    _emby_url = ""
+    _emby_apikey = ""
+    _use_emby = True
+    _use_ffprobe = True
+    # Plex 主机路径 => MoviePilot 容器路径；默认值适配当前部署
+    _ffprobe_path_map = "/Volumes/data=/media"
+    _ffprobe_timeout = 40
+    _overwrite_streams = True
+    _only_missing = True
+    _concurrency = 3
+    _sections = ""
+    _running = False
+
+    # ---- 自动补全触发配置 ----
+    _webhook_enabled = False
+    _dedup_window = 300
+    _forward_episodes = 5
+    # ratingKey -> 上次触发的单调时间戳，用于去重
+    _recent_triggers: Dict[str, float] = {}
+    _trigger_lock = Lock()
+    _helper_health_failures = 0
+    _helper_health_alerted = False
+    _helper_health_ok: Optional[bool] = None
+
+    def _proxy_signature(self) -> Tuple:
+        """
+        构建反代相关配置的签名，用于判断保存配置后是否需要重启代理。
+
+        :return: 反代配置签名元组
+        """
+        return (
+            self._enabled,
+            self._proxy_enabled,
+            self._plex_host,
+            self._plex_token,
+            self._host,
+            self._port,
+            self._pin_rules_raw,
+            self._force_direct_play,
+            self._dedup_window,
+        )
+
+    def init_plugin(self, config: Optional[Dict[str, Any]] = None) -> None:
+        """
+        初始化插件：解析配置，按需启动 302 代理。
+
+        仅当反代相关配置发生变化（或代理未在运行）时才重启代理，
+        避免每次保存补全配置都导致 Plex 播放断链。
+
+        :param config: 插件配置字典
+        """
+        old_sig = self._proxy_signature()
+        if config:
+            self._enabled = config.get("enabled", False)
+            # 反代
+            self._proxy_enabled = config.get("proxy_enabled", False)
+            self._plex_host = (config.get("plex_host") or "").strip()
+            self._plex_token = (config.get("plex_token") or "").strip()
+            self._host = (config.get("host") or "0.0.0.0").strip() or "0.0.0.0"
+            try:
+                self._port = int(config.get("port") or 32401)
+            except (TypeError, ValueError):
+                self._port = 32401
+            self._pin_rules_raw = (config.get("pin_rules") or "").strip()
+            self._pin_rules = _parse_pin_rules(self._pin_rules_raw)
+            self._force_direct_play = config.get("force_direct_play", True)
+            # 媒体信息补全
+            self._mediainfo_enabled = config.get("mediainfo_enabled", False)
+            self._plex_direct_host = (config.get("plex_direct_host") or "").strip()
+            self._helper_url = (config.get("helper_url") or "").strip()
+            self._helper_token = (config.get("helper_token") or "").strip()
+            self._emby_url = (config.get("emby_url") or "").strip()
+            self._emby_apikey = (config.get("emby_apikey") or "").strip()
+            self._use_emby = config.get("use_emby", True)
+            self._use_ffprobe = config.get("use_ffprobe", True)
+            ffprobe_path_map = config.get("ffprobe_path_map")
+            self._ffprobe_path_map = (
+                "/Volumes/data=/media"
+                if ffprobe_path_map is None
+                else str(ffprobe_path_map).strip()
+            )
+            try:
+                self._ffprobe_timeout = max(
+                    1, min(300, int(config.get("ffprobe_timeout") or 40))
+                )
+            except (TypeError, ValueError):
+                self._ffprobe_timeout = 40
+            self._overwrite_streams = config.get("overwrite_streams", True)
+            self._only_missing = config.get("only_missing", True)
+            try:
+                self._concurrency = int(config.get("concurrency") or 3)
+            except (TypeError, ValueError):
+                self._concurrency = 3
+            self._sections = (config.get("sections") or "").strip()
+            # 自动补全触发
+            self._webhook_enabled = config.get("webhook_enabled", False)
+            try:
+                self._dedup_window = int(config.get("dedup_window") or 300)
+            except (TypeError, ValueError):
+                self._dedup_window = 300
+            try:
+                self._forward_episodes = int(config.get("forward_episodes") or 5)
+            except (TypeError, ValueError):
+                self._forward_episodes = 5
+            self._update_config()
+
+        # 仅当反代相关配置变化或代理未运行时才重启代理，避免保存补全配置导致断链
+        new_sig = self._proxy_signature()
+        proxy_running = self._server is not None
+        if new_sig != old_sig or not proxy_running:
+            self.stop_service()
+            self._start_proxy()
+
+    def _start_proxy(self) -> None:
+        """按配置启动 302 反向代理服务。"""
+        if not (self._enabled and self._proxy_enabled and self._plex_host):
+            if self._enabled and self._proxy_enabled and not self._plex_host:
+                logger.warning("PlexToolbox 反代已启用但未配置 Plex 地址")
+            return
+        if not self._plex_host.startswith(("http://", "https://")):
+            self._plex_host = "http://" + self._plex_host
+        app = create_app(
+            self._plex_host,
+            plex_token=self._plex_token,
+            pin_rules=self._pin_rules,
+            force_direct_play=self._force_direct_play,
+            preplay_cooldown_seconds=self._dedup_window,
+            on_pre_play=self._on_pre_play_from_proxy,
+        )
+        try:
+            uv_config = Config(app=app, host=self._host, port=self._port, log_config=None)
+            self._server = Server(uv_config)
+            self._thread = Thread(target=self._server.run, daemon=True)
+            self._thread.start()
+            logger.info(
+                "PlexToolbox 302 代理已启动: %s:%s -> %s",
+                self._host, self._port, self._plex_host,
+            )
+        except Exception as e:
+            logger.error("PlexToolbox 代理启动失败: %s", e, exc_info=True)
+            self._server = None
+            self._thread = None
+
+    def _update_config(self) -> None:
+        """将当前配置写回插件配置存储。"""
+        self.update_config(
+            {
+                "enabled": self._enabled,
+                "proxy_enabled": self._proxy_enabled,
+                "plex_host": self._plex_host,
+                "plex_token": self._plex_token,
+                "host": self._host,
+                "port": self._port,
+                "pin_rules": self._pin_rules_raw,
+                "force_direct_play": self._force_direct_play,
+                "mediainfo_enabled": self._mediainfo_enabled,
+                "plex_direct_host": self._plex_direct_host,
+                "helper_url": self._helper_url,
+                "helper_token": self._helper_token,
+                "emby_url": self._emby_url,
+                "emby_apikey": self._emby_apikey,
+                "use_emby": self._use_emby,
+                "use_ffprobe": self._use_ffprobe,
+                "ffprobe_path_map": self._ffprobe_path_map,
+                "ffprobe_timeout": self._ffprobe_timeout,
+                "overwrite_streams": self._overwrite_streams,
+                "only_missing": self._only_missing,
+                "concurrency": self._concurrency,
+                "sections": self._sections,
+                "webhook_enabled": self._webhook_enabled,
+                "dedup_window": self._dedup_window,
+                "forward_episodes": self._forward_episodes,
+            }
+        )
+
+    def _build_completer(self, force_write: bool = False) -> Optional[MediaInfoCompleter]:
+        """
+        根据配置构建媒体信息补全器。
+
+        :param force_write: 是否忽略 Plex 繁忙强制写入
+        :return: 补全器实例，配置不全返回 None
+        """
+        plex_host = self._plex_direct_host or self._plex_host
+        if not plex_host or not self._plex_token:
+            logger.warning("PlexToolbox 补全缺少 Plex 直连地址或 token")
+            return None
+        if not self._helper_url:
+            logger.warning("PlexToolbox 补全缺少 helper 地址")
+            return None
+        if not plex_host.startswith(("http://", "https://")):
+            plex_host = "http://" + plex_host
+        plex = PlexClient(plex_host, self._plex_token)
+        helper = HelperClient(self._helper_url, self._helper_token)
+        emby = None
+        if self._use_emby and self._emby_url and self._emby_apikey:
+            emby = EmbyClient(self._emby_url, self._emby_apikey)
+        ffprobe = (
+            FfprobeSource(
+                path_map=self._ffprobe_path_map,
+                timeout=self._ffprobe_timeout,
+            )
+            if self._use_ffprobe
+            else None
+        )
+        return MediaInfoCompleter(
+            plex=plex,
+            helper=helper,
+            emby=emby,
+            use_emby=self._use_emby,
+            overwrite_streams=self._overwrite_streams,
+            concurrency=self._concurrency,
+            force_write=force_write,
+            ffprobe=ffprobe,
+            use_ffprobe=self._use_ffprobe,
+        )
+
+    def run_completion(
+        self, source: str = "manual", force_write: bool = False,
+        section_keys: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        执行媒体信息补全流程并持久化最近结果。
+
+        :param source: 触发来源（manual/schedule/api）
+        :param force_write: 是否忽略 Plex 繁忙强制写入
+        :param section_keys: 指定分区 key；缺省用配置中的 sections
+        :return: 汇总结果
+        """
+        if self._running:
+            return {"success": False, "error": "已有补全任务在运行"}
+        completer = self._build_completer(force_write=force_write)
+        if not completer:
+            return {"success": False, "error": "补全配置不完整"}
+        keys = section_keys or [
+            s.strip() for s in self._sections.split(",") if s.strip()
+        ]
+        if not keys:
+            return {"success": False, "error": "未指定要处理的 Plex 媒体库"}
+        self._running = True
+        try:
+            summary = completer.run(keys, only_missing=self._only_missing)
+            summary["success"] = True
+            summary["source"] = source
+            self.save_data("last_result", summary)
+            logger.info("PlexToolbox 补全完成: %s", summary)
+            return summary
+        except Exception as e:
+            logger.error("PlexToolbox 补全异常: %s", e, exc_info=True)
+            return {"success": False, "error": str(e)}
+        finally:
+            self._running = False
+
+    def _should_trigger(self, rating_key: str) -> bool:
+        """
+        判断某 ratingKey 是否可触发补全（去重窗口内不重复触发）。
+
+        :param rating_key: Plex 条目 ratingKey
+        :return: True 表示允许触发并已记录时间戳
+        """
+        now = monotonic()
+        with self._trigger_lock:
+            # 顺带清理过期记录
+            expired = [
+                k for k, ts in self._recent_triggers.items()
+                if now - ts > self._dedup_window
+            ]
+            for k in expired:
+                self._recent_triggers.pop(k, None)
+            last = self._recent_triggers.get(rating_key)
+            if last is not None and now - last <= self._dedup_window:
+                return False
+            self._recent_triggers[rating_key] = now
+            return True
+
+    def _append_play_history(self, summary: Dict[str, Any]) -> None:
+        """
+        将一次增量补全结果追加到播放补全历史（保留最近若干条），供数据页展示。
+
+        :param summary: run_rating_key 的汇总结果
+        """
+        try:
+            history = self.get_data("play_history") or []
+            if not isinstance(history, list):
+                history = []
+            entry = {
+                "ts": int(summary.get("ts") or time()),
+                "rating_key": summary.get("rating_key"),
+                "label": summary.get("label") or "",
+                "source": summary.get("source"),
+                "strm_parts": summary.get("strm_parts", 0),
+                "resolved": summary.get("resolved", 0),
+                "emby_hits": summary.get("emby_hits", 0),
+                "ffprobe_hits": summary.get("ffprobe_hits", 0),
+                "written_ok": summary.get("written_ok", 0),
+                "write_failed": summary.get("write_failed", 0),
+                "unresolved": summary.get("unresolved", 0),
+                "helper_busy": summary.get("helper_busy", False),
+                # 逐条明细（label+状态），最多留 20 条防膨胀
+                "items": (summary.get("items") or [])[:20],
+            }
+            history.insert(0, entry)
+            self.save_data("play_history", history[:50])
+        except Exception as exc:
+            logger.debug("PlexToolbox 记录播放补全历史失败: %s", exc)
+
+    def _rating_key_in_selected_sections(self, rating_key: str) -> bool:
+        """检查单条播放补全是否属于用户已选择的 Plex 媒体库。"""
+        selected = {item.strip() for item in self._sections.split(",") if item.strip()}
+        if not selected:
+            logger.info("PlexToolbox 跳过单条补全：未选择 Plex 媒体库 ratingKey=%s", rating_key)
+            return False
+        plex_host = self._plex_direct_host or self._plex_host
+        if not plex_host or not self._plex_token:
+            return False
+        if not plex_host.startswith(("http://", "https://")):
+            plex_host = "http://" + plex_host
+        section_key = PlexClient(plex_host, self._plex_token).item_section_key(rating_key)
+        if not section_key:
+            logger.warning("PlexToolbox 无法确认条目所属媒体库，跳过补全 ratingKey=%s", rating_key)
+            return False
+        if section_key not in selected:
+            logger.info(
+                "PlexToolbox 跳过单条补全：条目不在已选媒体库 ratingKey=%s section=%s",
+                rating_key, section_key,
+            )
+            return False
+        return True
+
+    def complete_rating_key(self, rating_key: str, source: str = "webhook") -> None:
+        """
+        针对单个条目 ratingKey 触发补全，带去重，在后台线程执行。
+
+        :param rating_key: Plex 条目 ratingKey
+        :param source: 触发来源（webhook）
+        """
+        if not rating_key:
+            return
+        if not (self._enabled and self._mediainfo_enabled):
+            return
+        if not self._rating_key_in_selected_sections(str(rating_key)):
+            return
+        if not self._should_trigger(str(rating_key)):
+            logger.debug("PlexToolbox 去重窗口内跳过 ratingKey=%s", rating_key)
+            return
+
+        def _worker() -> None:
+            """后台线程执行单条补全。"""
+            completer = self._build_completer(force_write=False)
+            if not completer:
+                return
+            try:
+                summary = completer.run_rating_key(
+                    str(rating_key),
+                    only_missing=self._only_missing,
+                    forward=self._forward_episodes,
+                )
+                summary["success"] = True
+                summary["source"] = source
+                self.save_data("last_play_result", summary)
+                self._append_play_history(summary)
+                logger.info(
+                    "PlexToolbox 条目补全完成 (%s) %s: 处理 %s, 写入 %s, 未命中 %s",
+                    source,
+                    summary.get("label") or f"ratingKey={rating_key}",
+                    summary.get("strm_parts", 0),
+                    summary.get("written_ok", 0),
+                    summary.get("unresolved", 0),
+                )
+            except Exception as exc:
+                logger.error(
+                    "PlexToolbox 单条补全异常 ratingKey=%s: %s",
+                    rating_key, exc, exc_info=True,
+                )
+
+        Thread(target=_worker, daemon=True).start()
+
+    def _on_pre_play_from_proxy(self, rating_key: str) -> None:
+        """
+        反代播前回调（同步阻塞）：播放/继续观看起播前，先补全该条目媒体流信息。
+
+        覆盖「继续观看」点击即播不经过详情页的场景。仅补当前条目本身
+        当前条目与配置的后续集都在播放前处理。反代侧带等待预算，
+        超时自动放行播放，补全任务转后台继续。
+
+        :param rating_key: 即将播放条目的 ratingKey
+        """
+        if not (self._enabled and self._mediainfo_enabled):
+            return
+        if not self._rating_key_in_selected_sections(str(rating_key)):
+            return
+        completer = self._build_completer(force_write=True)
+        if not completer:
+            return
+        try:
+            summary = completer.run_rating_key(
+                str(rating_key), only_missing=True, forward=self._forward_episodes,
+            )
+            summary["success"] = True
+            summary["source"] = "pre_play"
+            summary["ts"] = int(time())
+            self.save_data("last_play_result", summary)
+            self._append_play_history(summary)
+            if summary.get("written_ok"):
+                logger.info(
+                    "PlexToolbox 播前补全 %s: 写入 %s 条",
+                    summary.get("label") or f"ratingKey={rating_key}",
+                    summary.get("written_ok"),
+                )
+        except Exception as exc:
+            logger.debug("PlexToolbox 播前补全异常 ratingKey=%s: %s", rating_key, exc)
+
+    def get_state(self) -> bool:
+        """返回插件启用状态。"""
+        return self._enabled
+
+    @staticmethod
+    def get_render_mode() -> Tuple[str, Optional[str]]:
+        """声明使用 Vue 联邦组件渲染。"""
+        return "vue", "dist/assets"
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """返回插件远程命令列表。"""
+        return [
+            {
+                "cmd": "/ptbox",
+                "event": EventType.PluginAction,
+                "desc": "PLEX 工具箱媒体信息补全",
+                "category": "PLEX 工具箱",
+                "data": {"action": "plextoolbox_complete"},
+            }
+        ]
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """返回 Helper 健康检查服务。"""
+        if not (self._enabled and self._mediainfo_enabled and self._helper_url):
+            return []
+        trigger = IntervalTrigger(minutes=5) if IntervalTrigger else "*/5 * * * *"
+        return [
+            {
+                "id": "plextoolbox_helper_health",
+                "name": "PLEX 工具箱 Helper 健康检查",
+                "trigger": trigger,
+                "func": self.check_helper_health,
+            }
+        ]
+
+    def check_helper_health(self) -> None:
+        """每 5 分钟检查 Helper；连续失败 3 次后仅告警一次。"""
+        healthy = HelperClient(self._helper_url, self._helper_token).health()
+        self._helper_health_ok = healthy
+        if healthy:
+            if self._helper_health_failures:
+                logger.info("PlexToolbox Helper 已恢复正常")
+            self._helper_health_failures = 0
+            self._helper_health_alerted = False
+            return
+        self._helper_health_failures += 1
+        logger.warning("PlexToolbox Helper 健康检查失败：连续 %s 次", self._helper_health_failures)
+        if self._helper_health_failures >= 3 and not self._helper_health_alerted:
+            self.post_message(
+                mtype=NotificationType.Plugin,
+                title="PLEX 工具箱 Helper 异常",
+                text="Helper 连续 3 次检测失败（约 15 分钟），请检查 Helper 服务和网络连接。",
+            )
+            self._helper_health_alerted = True
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """返回插件前端调用的 API 列表。"""
+        return [
+            {"path": "/status", "endpoint": self.status_api, "methods": ["GET"], "auth": "bear", "summary": "工具箱状态"},
+            {"path": "/config", "endpoint": self.get_config_api, "methods": ["GET"], "auth": "bear", "summary": "获取插件配置"},
+            {"path": "/config", "endpoint": self.save_config_api, "methods": ["POST"], "auth": "bear", "summary": "保存插件配置"},
+            {"path": "/sections", "endpoint": self.sections_api, "methods": ["GET"], "auth": "bear", "summary": "获取 Plex 媒体库"},
+            {"path": "/helper_check", "endpoint": self.helper_check_api, "methods": ["GET"], "auth": "bear", "summary": "检查 helper 连通与数据库"},
+            {"path": "/complete", "endpoint": self.complete_api, "methods": ["POST"], "auth": "bear", "summary": "手动触发媒体信息补全"},
+            {"path": "/result", "endpoint": self.result_api, "methods": ["GET"], "auth": "bear", "summary": "获取最近补全结果"},
+            {"path": "/webhook", "endpoint": self.webhook_api, "methods": ["POST"], "auth": "apikey", "summary": "Plex Webhook 接收"},
+            {"path": "/unmatch", "endpoint": self.unmatch_api, "methods": ["POST"], "auth": "bear", "summary": "一键取消匹配（重读 NFO）"},
+            {"path": "/scan_cover", "endpoint": self.scan_cover_api, "methods": ["POST"], "auth": "bear", "summary": "扫描缺封面条目"},
+            {"path": "/scrape", "endpoint": self.scrape_api, "methods": ["POST"], "auth": "bear", "summary": "对缺封面条目触发 MP 刮削"},
+            {"path": "/fix_poster", "endpoint": self.fix_poster_api, "methods": ["POST"], "auth": "bear", "summary": "补全缺失的 poster.jpg（季海报复制/TMDB）"},
+            {"path": "/clear_completion_data", "endpoint": self.clear_completion_data_api, "methods": ["POST"], "auth": "bear", "summary": "一键清理补全结果/播放补全历史"},
+            {"path": "/merge_scan", "endpoint": self.merge_scan_api, "methods": ["GET"], "auth": "bear", "summary": "扫描重复条目"},
+            {"path": "/merge_execute", "endpoint": self.merge_execute_api, "methods": ["POST"], "auth": "bear", "summary": "执行重复条目合并"},
+        ]
+
+    def get_config_api(self) -> Dict[str, Any]:
+        """返回当前完整配置，供配置页与数据页共用。"""
+        return {"success": True, "data": self.get_form()[1]}
+
+    def save_config_api(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """保存完整配置并重新初始化插件，使新配置立即生效。"""
+        payload = payload or {}
+        try:
+            merged = {**self.get_form()[1], **payload}
+            self.update_config(merged)
+            self.init_plugin(merged)
+            return {"success": True, "message": "配置已保存"}
+        except Exception as exc:
+            logger.error("PlexToolbox 保存配置失败: %s", exc, exc_info=True)
+            return {"success": False, "message": str(exc)}
+
+    def status_api(self) -> Dict[str, Any]:
+        """返回工具箱运行状态与配置概要。"""
+        return {
+            "success": True,
+            "enabled": self._enabled,
+            "proxy_enabled": self._proxy_enabled,
+            "proxy_running": self._server is not None,
+            "mediainfo_enabled": self._mediainfo_enabled,
+            "running": self._running,
+            "use_emby": self._use_emby,
+            "use_ffprobe": self._use_ffprobe,
+            "helper_health_ok": self._helper_health_ok,
+            "helper_health_failures": self._helper_health_failures,
+        }
+
+    def sections_api(self) -> Dict[str, Any]:
+        """获取 Plex 媒体库分区列表，供前端勾选。"""
+        plex_host = self._plex_direct_host or self._plex_host
+        if not plex_host or not self._plex_token:
+            return {"success": False, "error": "未配置 Plex 直连地址或 token", "sections": []}
+        if not plex_host.startswith(("http://", "https://")):
+            plex_host = "http://" + plex_host
+        try:
+            sections = PlexClient(plex_host, self._plex_token).list_sections()
+            return {"success": True, "sections": sections}
+        except Exception as e:
+            return {"success": False, "error": str(e), "sections": []}
+
+    def helper_check_api(self) -> Dict[str, Any]:
+        """检查 helper 连通性与数据库探测结果。"""
+        if not self._helper_url:
+            return {"success": False, "error": "未配置 helper 地址"}
+        client = HelperClient(self._helper_url, self._helper_token)
+        if not client.health():
+            return {"success": False, "error": "helper 不可达"}
+        info = client.dbinfo()
+        return {"success": True, "health": True, "dbinfo": info}
+
+    def complete_api(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """手动触发媒体信息补全。"""
+        payload = payload or {}
+        keys = payload.get("sections")
+        force = bool(payload.get("force"))
+        return self.run_completion(source="api", force_write=force, section_keys=keys)
+
+    def result_api(self) -> Dict[str, Any]:
+        """获取最近一次补全结果与播放增量补全历史。"""
+        return {
+            "success": True,
+            "result": self.get_data("last_result") or {},
+            "last_play_result": self.get_data("last_play_result") or {},
+            "play_history": self.get_data("play_history") or [],
+        }
+
+    async def webhook_api(self, request: Request) -> Dict[str, Any]:
+        """
+        接收 Plex Webhook，识别 media.stop 事件并触发针对性补全。
+
+        Plex Webhook 以 multipart/form-data 提交，payload 字段为 JSON 文本。
+        仅当 webhook 开关开启时处理；只对 media.stop（可选 media.scrobble）触发。
+
+        :param request: FastAPI 请求对象
+        :return: 处理结果
+        """
+        if not (self._enabled and self._mediainfo_enabled and self._webhook_enabled):
+            return {"success": False, "error": "webhook 未启用"}
+        payload_text = ""
+        try:
+            form = await request.form()
+            payload_text = form.get("payload") or ""
+        except Exception:
+            try:
+                payload_text = (await request.body()).decode("utf-8", "replace")
+            except Exception:
+                payload_text = ""
+        if not payload_text:
+            return {"success": False, "error": "空 payload"}
+        try:
+            data = json.loads(payload_text)
+        except Exception:
+            return {"success": False, "error": "payload 非 JSON"}
+        event = data.get("event") or ""
+        if event not in ("media.stop", "media.scrobble"):
+            return {"success": True, "skipped": event}
+        rating_key = (data.get("Metadata") or {}).get("ratingKey")
+        if not rating_key:
+            return {"success": False, "error": "无 ratingKey"}
+        self.complete_rating_key(str(rating_key), source="webhook")
+        return {"success": True, "event": event, "ratingKey": rating_key}
+
+    def _plex_direct(self) -> Optional[PlexClient]:
+        """构建用于枚举/写操作的 Plex 直连客户端。"""
+        plex_host = self._plex_direct_host or self._plex_host
+        if not plex_host or not self._plex_token:
+            return None
+        if not plex_host.startswith(("http://", "https://")):
+            plex_host = "http://" + plex_host
+        return PlexClient(plex_host, self._plex_token)
+
+    def _scrape_dir(self, dir_path: str) -> Dict[str, Any]:
+        """
+        调用 MoviePilot 对本地目录刮削生成 NFO+图片。
+
+        :param dir_path: STRM 媒体目录绝对路径
+        :return: {success: bool}
+        """
+        try:
+            from pathlib import Path
+            from app import schemas
+            from app.chain.media import MediaChain
+
+            p = Path(dir_path)
+            if not p.is_dir():
+                return {"success": False, "error": "目录不存在"}
+            chain = MediaChain()
+            context = chain.recognize_by_path(p.as_posix(), obtain_images=True)
+            if not context or not context.media_info:
+                return {"success": False, "error": "无法识别"}
+            chain.scrape_metadata(
+                fileitem=schemas.FileItem(
+                    storage="local",
+                    type="dir",
+                    path=p.as_posix() + "/",
+                    name=p.name,
+                    basename=p.stem,
+                    modify_time=p.stat().st_mtime,
+                ),
+                meta=context.meta_info,
+                mediainfo=context.media_info,
+                overwrite=False,
+            )
+            return {"success": True}
+        except Exception as exc:
+            logger.error("MP 刮削目录失败 %s: %s", dir_path, exc, exc_info=True)
+            return {"success": False, "error": str(exc)}
+
+    def unmatch_api(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """
+        一键取消匹配 API：dry-run 统计或执行 unmatch（可选 rematch）。
+
+        :param payload: {section, dry_run, rematch, limit}
+        :return: 结果
+        """
+        payload = payload or {}
+        section = str(payload.get("section") or "").strip()
+        if not section:
+            return {"success": False, "error": "未指定分区"}
+        plex = self._plex_direct()
+        if not plex:
+            return {"success": False, "error": "未配置 Plex 直连地址或 token"}
+        tools = ScrapeTools(plex)
+        res = tools.unmatch_section(
+            section,
+            dry_run=bool(payload.get("dry_run", True)),
+            rematch=bool(payload.get("rematch", True)),
+            limit=int(payload.get("limit") or 0),
+        )
+        res["success"] = True
+        return res
+
+    def scan_cover_api(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """
+        扫描分区缺封面条目 API。
+
+        :param payload: {section}
+        :return: 结果
+        """
+        payload = payload or {}
+        section = str(payload.get("section") or "").strip()
+        if not section:
+            return {"success": False, "error": "未指定分区"}
+        plex = self._plex_direct()
+        if not plex:
+            return {"success": False, "error": "未配置 Plex 直连地址或 token"}
+        tools = ScrapeTools(plex)
+        res = tools.scan_missing_cover(section)
+        res["success"] = True
+        # missing 列表可能较长，仅返回前 50 条明细
+        res["missing"] = res.get("missing", [])[:50]
+        return res
+
+    def scrape_api(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """
+        对缺封面条目调用 MP 刮削 API：dry-run 列目录或执行。
+
+        :param payload: {section, dry_run, limit, unmatch_after}
+        :return: 结果
+        """
+        payload = payload or {}
+        section = str(payload.get("section") or "").strip()
+        if not section:
+            return {"success": False, "error": "未指定分区"}
+        plex = self._plex_direct()
+        if not plex:
+            return {"success": False, "error": "未配置 Plex 直连地址或 token"}
+        tools = ScrapeTools(plex)
+        res = tools.scrape_missing(
+            section,
+            scrape_cb=self._scrape_dir,
+            dry_run=bool(payload.get("dry_run", True)),
+            limit=int(payload.get("limit") or 0),
+            unmatch_after=bool(payload.get("unmatch_after", False)),
+        )
+        res["success"] = True
+        return res
+
+    def fix_poster_api(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """
+        缺 poster.jpg 补全 API：dry-run 列出待修复条目或执行补全。
+
+        电影从 TMDB 取海报（原产语言→zh→无字→任意）；剧集优先复制季内
+        Season X/poster.jpg 到剧根，无则回退 TMDB。修复后自动 refresh。
+
+        :param payload: {section, dry_run, limit}
+        :return: 结果
+        """
+        payload = payload or {}
+        section = str(payload.get("section") or "").strip()
+        if not section:
+            return {"success": False, "error": "未指定分区"}
+        plex = self._plex_direct()
+        if not plex:
+            return {"success": False, "error": "未配置 Plex 直连地址或 token"}
+        try:
+            fixer = PosterFixer(plex)
+            res = fixer.fix(
+                section,
+                dry_run=bool(payload.get("dry_run", True)),
+                limit=int(payload.get("limit") or 0),
+            )
+            res["success"] = True
+            # 明细可能较长，限制返回条数
+            if "targets" in res:
+                res["targets"] = res["targets"][:50]
+            if "details" in res:
+                res["details"] = res["details"][:50]
+            return res
+        except Exception as exc:
+            logger.error("缺 poster 补全异常: %s", exc, exc_info=True)
+            return {"success": False, "error": str(exc)}
+
+    def clear_completion_data_api(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """
+        清理补全数据 API：清理最近一次补全结果、播放补全结果或播放补全历史。
+
+        :param payload: {target}，target 可选 'last_result'、'last_play_result'、'play_history'、'all'
+        :return: 结果
+        """
+        payload = payload or {}
+        target = str(payload.get("target") or "all").strip()
+        cleared = []
+        if target in ("last_result", "all"):
+            self.save_data("last_result", None)
+            cleared.append("last_result")
+        if target in ("last_play_result", "all"):
+            self.save_data("last_play_result", None)
+            cleared.append("last_play_result")
+        if target in ("play_history", "all"):
+            self.save_data("play_history", [])
+            cleared.append("play_history")
+        if not cleared:
+            return {"success": False, "error": f"未知的清理目标: {target}"}
+        return {"success": True, "cleared": cleared, "message": f"已清理: {', '.join(cleared)}"}
+
+    def merge_scan_api(self) -> Dict[str, Any]:
+        """扫描 Plex 媒体库中 tmdb id 相同的重复条目。"""
+        plex = self._plex_direct()
+        if not plex:
+            return {"success": False, "error": "未配置 Plex 直连地址或 token"}
+        try:
+            groups = plex.scan_duplicate_items(media_types=("movie", "show"))
+            return {"success": True, "groups": groups, "total_groups": len(groups)}
+        except Exception as exc:
+            logger.error("PlexToolbox 扫描重复条目异常: %s", exc, exc_info=True)
+            return {"success": False, "error": str(exc)}
+
+    def merge_execute_api(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """
+        执行重复条目合并 API。
+
+        :param payload: {merges: [{primary, others: [ratingKey...]}]}
+        :return: 合并结果
+        """
+        payload = payload or {}
+        merges = payload.get("merges") or []
+        if not merges:
+            return {"success": False, "error": "未指定合并计划"}
+        plex = self._plex_direct()
+        if not plex:
+            return {"success": False, "error": "未配置 Plex 直连地址或 token"}
+        merged = 0
+        failed: List[str] = []
+        for m in merges:
+            primary = str(m.get("primary") or "").strip()
+            others = [str(x) for x in (m.get("others") or []) if str(x)]
+            if not primary or not others:
+                continue
+            if plex.merge_items(primary, others):
+                merged += 1
+            else:
+                failed.append(primary)
+        return {"success": True, "merged": merged, "failed": failed}
+
+    def get_form(self) -> Tuple[Optional[List[dict]], Dict[str, Any]]:
+        """Vue 模式下返回默认配置模型。"""
+        return None, {
+            "enabled": self._enabled,
+            "proxy_enabled": self._proxy_enabled,
+            "plex_host": self._plex_host,
+            "plex_token": self._plex_token,
+            "host": self._host,
+            "port": self._port,
+            "pin_rules": self._pin_rules_raw,
+            "force_direct_play": self._force_direct_play,
+            "mediainfo_enabled": self._mediainfo_enabled,
+            "plex_direct_host": self._plex_direct_host,
+            "helper_url": self._helper_url,
+            "helper_token": self._helper_token,
+            "emby_url": self._emby_url,
+            "emby_apikey": self._emby_apikey,
+            "use_emby": self._use_emby,
+            "use_ffprobe": self._use_ffprobe,
+            "ffprobe_path_map": self._ffprobe_path_map,
+            "ffprobe_timeout": self._ffprobe_timeout,
+            "overwrite_streams": self._overwrite_streams,
+            "only_missing": self._only_missing,
+            "concurrency": self._concurrency,
+            "sections": self._sections,
+            "webhook_enabled": self._webhook_enabled,
+            "dedup_window": self._dedup_window,
+            "forward_episodes": self._forward_episodes,
+        }
+
+    def get_page(self) -> Optional[List[dict]]:
+        """Vue 模式下详情页由远程组件渲染。"""
+        return None
+
+    def stop_service(self) -> None:
+        """停止代理服务并释放资源。"""
+        if self._server is not None:
+            try:
+                self._server.should_exit = True
+                if self._thread is not None and self._thread.is_alive():
+                    self._thread.join(timeout=5.0)
+                logger.info("PlexToolbox 302 代理已停止")
+            except Exception as e:
+                logger.error("PlexToolbox 停止异常: %s", e, exc_info=True)
+            finally:
+                self._server = None
+                self._thread = None

--- a/plugins.v3/plextoolbox/dist/assets/__federation_expose_Config-C2jHLi0c.css
+++ b/plugins.v3/plextoolbox/dist/assets/__federation_expose_Config-C2jHLi0c.css
@@ -1,0 +1,91 @@
+
+.ptb-config[data-v-d649379b] { container-type: inline-size; width: min(1120px, calc(100vw - 48px)); max-width: 100%; height: calc(100dvh - 16px); max-height: calc(100dvh - 16px); padding: 8px; margin: 0 auto; display: flex;
+}
+.ptb-card[data-v-d649379b] { width: 100%; height: 100%; min-height: 0; display: flex; flex-direction: column; border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity)); border-radius: 14px; overflow: hidden;
+}
+.ptb-header[data-v-d649379b] { padding: 14px 18px;
+}
+.ptb-header-subtitle[data-v-d649379b] { max-width: min(560px, 52vw); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ptb-body[data-v-d649379b] { flex: 1 1 auto; min-height: 0; display: flex;
+}
+.ptb-nav[data-v-d649379b] { width: 168px; flex: 0 0 168px; border-right: 1px solid rgba(var(--v-border-color), var(--v-border-opacity)); background: rgba(var(--v-theme-on-surface), .02);
+}
+.ptb-nav-item[data-v-d649379b] { margin: 2px 8px;
+}
+.ptb-content[data-v-d649379b] { flex: 1 1 auto; min-width: 0; min-height: 0; display: flex; flex-direction: column;
+}
+.ptb-error-alert[data-v-d649379b] { flex: 0 0 auto; min-height: 44px;
+}
+.ptb-dirty-hint[data-v-d649379b] { display: flex; align-items: center;
+}
+.ptb-mobile-tabbar[data-v-d649379b] { display: none;
+}
+.ptb-workspace[data-v-d649379b] { flex: 1 1 auto; min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow-y: auto;
+}
+.ptb-window[data-v-d649379b] { flex: 0 0 auto; min-width: 0;
+}
+.ptb-pane[data-v-d649379b] { padding: 18px 20px;
+}
+.ptb-section-title[data-v-d649379b] { color: rgb(var(--v-theme-primary)); font-size: 14px; font-weight: 700; margin-bottom: 12px;
+}
+.ptb-subsection-title[data-v-d649379b], .ptb-block-title[data-v-d649379b] { font-size: 13px; font-weight: 700;
+}
+.ptb-doc-link[data-v-d649379b] { color: rgb(var(--v-theme-primary)); text-decoration: underline; font-weight: 600;
+}
+.ptb-target-grid[data-v-d649379b] { display: grid; grid-template-columns: minmax(0, 2fr) minmax(130px, 1fr); gap: 12px;
+}
+.ptb-stat-grid[data-v-d649379b] { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 10px;
+}
+.ptb-stat[data-v-d649379b] { padding: 10px 12px; border-left: 3px solid rgb(var(--v-theme-primary)); border-radius: 8px; background: rgba(var(--v-theme-on-surface), .03);
+}
+.ptb-stat-value[data-v-d649379b] { font-size: 1.25rem; font-weight: 700;
+}
+.ptb-stat-label[data-v-d649379b] { font-size: .75rem; opacity: .7;
+}
+.ptb-history th[data-v-d649379b] { font-size: .72rem; opacity: .7;
+}
+.ptb-row[data-v-d649379b] { cursor: pointer;
+}
+.ptb-detail-cell[data-v-d649379b] { background: rgba(var(--v-theme-on-surface), .03);
+}
+.ptb-dashboard[data-v-d649379b] { flex: 0 0 auto; margin: 0 12px 12px; padding: 14px 16px; border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity)); border-radius: 8px; background: rgba(var(--v-theme-on-surface), .015);
+}
+.ptb-dashboard-title[data-v-d649379b] { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; font-size: 14px; font-weight: 700;
+}
+.ptb-dashboard-row[data-v-d649379b] { display: grid; grid-template-columns: 24px minmax(0, 1fr) auto; align-items: center; gap: 8px; min-height: 38px; color: rgba(var(--v-theme-on-surface), .68); font-size: 13px;
+}
+.ptb-dashboard-row strong[data-v-d649379b] { color: rgb(var(--v-theme-on-surface)); text-align: right; overflow-wrap: anywhere;
+}
+@container (min-width: 880px) {
+.ptb-workspace[data-v-d649379b] { display: grid; grid-template-columns: minmax(0, 1fr) 252px; overflow: hidden;
+}
+.ptb-window[data-v-d649379b] { min-height: 0; overflow-y: auto;
+}
+.ptb-dashboard[data-v-d649379b] { margin: 0; padding: 18px 16px; border-width: 0 0 0 1px; border-radius: 0; overflow-y: auto;
+}
+}
+@media (max-width: 640px) {
+.ptb-config[data-v-d649379b] { width: 100%; height: 100dvh; max-height: 100dvh; padding: 0;
+}
+.ptb-card[data-v-d649379b] { border: 0; border-radius: 0;
+}
+.ptb-header[data-v-d649379b] { padding: 8px 10px;
+}
+.ptb-header-title[data-v-d649379b] { font-size: 15px;
+}
+.ptb-dirty-hint[data-v-d649379b] { display: none;
+}
+.ptb-body[data-v-d649379b] { flex-direction: column;
+}
+.ptb-nav[data-v-d649379b] { display: none;
+}
+.ptb-mobile-tabbar[data-v-d649379b] { display: flex; align-items: center; gap: 10px; padding: 10px 12px; border-bottom: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+}
+.ptb-mobile-tabinfo[data-v-d649379b] { flex: 1 1 auto; min-width: 0;
+}
+.ptb-pane[data-v-d649379b] { padding: 12px;
+}
+.ptb-target-grid[data-v-d649379b] { grid-template-columns: 1fr;
+}
+}

--- a/plugins.v3/plextoolbox/dist/assets/__federation_expose_Config-DKmiLaR4.js
+++ b/plugins.v3/plextoolbox/dist/assets/__federation_expose_Config-DKmiLaR4.js
@@ -1,0 +1,1493 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+
+function unwrapResponse(response) {
+  const data = response?.data ?? response;
+  if (data && typeof data === 'object' && 'data' in data) return data.data
+  return data
+}
+
+async function getPluginApi(api, path) {
+  if (!api?.get) throw new Error('缺少 MoviePilot 注入的 api.get')
+  return unwrapResponse(await api.get(`plugin/PlexToolbox/${path}`))
+}
+
+async function postPluginApi(api, path, payload = {}) {
+  if (!api?.post) throw new Error('缺少 MoviePilot 注入的 api.post')
+  return unwrapResponse(await api.post(`plugin/PlexToolbox/${path}`, payload))
+}
+
+const _export_sfc = (sfc, props) => {
+  const target = sfc.__vccOpts || sfc;
+  for (const [key, val] of props) {
+    target[key] = val;
+  }
+  return target;
+};
+
+const {resolveComponent:_resolveComponent,createVNode:_createVNode,withCtx:_withCtx,createTextVNode:_createTextVNode,toDisplayString:_toDisplayString,createElementVNode:_createElementVNode,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,createBlock:_createBlock,renderList:_renderList,Fragment:_Fragment,createSlots:_createSlots,vShow:_vShow,withDirectives:_withDirectives,withModifiers:_withModifiers,unref:_unref,normalizeClass:_normalizeClass} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "ptb-config" };
+const _hoisted_2 = { class: "d-flex align-center ga-2" };
+const _hoisted_3 = {
+  key: 0,
+  class: "ptb-dirty-hint"
+};
+const _hoisted_4 = { class: "text-caption text-warning" };
+const _hoisted_5 = { class: "ptb-body" };
+const _hoisted_6 = { class: "ptb-nav" };
+const _hoisted_7 = { class: "ptb-content" };
+const _hoisted_8 = { class: "ptb-mobile-tabbar" };
+const _hoisted_9 = { class: "ptb-mobile-tabinfo" };
+const _hoisted_10 = { class: "font-weight-medium" };
+const _hoisted_11 = { class: "text-caption text-medium-emphasis" };
+const _hoisted_12 = { class: "ptb-workspace" };
+const _hoisted_13 = { class: "ptb-window" };
+const _hoisted_14 = { class: "ptb-pane" };
+const _hoisted_15 = { class: "ptb-pane" };
+const _hoisted_16 = { class: "ptb-pane" };
+const _hoisted_17 = { class: "d-flex align-center flex-wrap ga-1 mb-3" };
+const _hoisted_18 = { class: "d-flex align-center mb-2" };
+const _hoisted_19 = {
+  key: 0,
+  class: "text-body-2 font-weight-medium mb-2"
+};
+const _hoisted_20 = { class: "ptb-stat-grid mb-3" };
+const _hoisted_21 = { class: "text-caption" };
+const _hoisted_22 = {
+  key: 0,
+  class: "text-caption text-error ml-2"
+};
+const _hoisted_23 = { class: "d-flex align-center mb-2" };
+const _hoisted_24 = { class: "ptb-block-title" };
+const _hoisted_25 = ["onClick"];
+const _hoisted_26 = { key: 0 };
+const _hoisted_27 = {
+  colspan: "3",
+  class: "ptb-detail-cell"
+};
+const _hoisted_28 = { class: "text-caption ml-2" };
+const _hoisted_29 = { class: "ptb-pane" };
+const _hoisted_30 = { class: "d-flex ga-2 flex-wrap mt-4" };
+const _hoisted_31 = { class: "ptb-pane" };
+const _hoisted_32 = { class: "d-flex ga-2 flex-wrap" };
+const _hoisted_33 = { class: "d-flex ga-2 flex-wrap" };
+const _hoisted_34 = { class: "ptb-pane" };
+const _hoisted_35 = { class: "d-flex ga-2 flex-wrap mb-3" };
+const _hoisted_36 = { class: "text-caption text-medium-emphasis mb-2" };
+const _hoisted_37 = { class: "text-caption" };
+const _hoisted_38 = { class: "text-caption" };
+const _hoisted_39 = { class: "text-caption" };
+const _hoisted_40 = {
+  class: "ptb-dashboard",
+  "aria-label": "运行表盘"
+};
+const _hoisted_41 = { class: "ptb-dashboard-title" };
+const _hoisted_42 = { class: "ptb-dashboard-title" };
+
+const {computed,defineComponent,h,onMounted,reactive,ref,resolveComponent,watch} = await importShared('vue');
+
+const helperDocUrl = 'https://github.com/ranzhigg/MoviePilot-Plugins/blob/main/plugins.v3/plextoolbox/helper/README.md';
+
+const _sfc_main = {
+  __name: 'Config',
+  props: { initialConfig: { type: Object, default: () => ({}) }, api: { type: [Object, Function], default: null } },
+  emits: ['save', 'close', 'layout'],
+  setup(__props, { emit: __emit }) {
+
+const props = __props;
+const emit = __emit;
+const layoutRequest = { maxWidth: '70rem' };
+emit('layout', layoutRequest);
+const VIconComponent = resolveComponent('VIcon');
+const VSelectComponent = resolveComponent('VSelect');
+const VTextFieldComponent = resolveComponent('VTextField');
+
+const tabs = [
+  { key: 'proxy', title: '反向代理', icon: 'mdi-swap-horizontal-bold', desc: 'Plex 播放流 302 直链跳转' },
+  { key: 'mediainfo', title: '媒体信息补全', icon: 'mdi-information-outline', desc: '为 STRM 条目补全媒体流信息' },
+  { key: 'records', title: '补全记录', icon: 'mdi-history', desc: '最近一次补全与历史执行记录' },
+  { key: 'matching', title: '目录匹配', icon: 'mdi-link-variant-off', desc: '预览并执行取消匹配重读 NFO' },
+  { key: 'scraping', title: '刮削与海报', icon: 'mdi-image-search-outline', desc: '缺封面扫描、刮削和 poster 补全' },
+  { key: 'merge', title: '合并重复', icon: 'mdi-call-merge', desc: '扫描并合并 tmdb id 相同的重复条目' },
+];
+const activeTab = ref('proxy');
+const currentTab = computed(() => tabs.find(item => item.key === activeTab.value) || tabs[0]);
+const mobileTabSheet = ref(false);
+const error = ref('');
+const checking = ref(false);
+const loadingSections = ref(false);
+const loadingRuntime = ref(false);
+const saving = ref(false);
+const saveMessage = ref('');
+const saveSnackbar = ref(false);
+const helperInfo = ref('');
+const sectionOptions = ref([]);
+const status = ref({});
+const lastPlay = ref(null);
+const history = ref([]);
+const expanded = ref(-1);
+const clearing = ref('');
+const scrapeSection = ref('');
+const scrapeLimit = ref(0);
+const busyKey = ref('');
+const matchingResult = ref(null);
+const scrapingResult = ref(null);
+const mergeGroups = ref([]);
+const mergeScanned = ref(false);
+const mergeResult = ref(null);
+
+const defaults = { enabled: false, proxy_enabled: false, plex_host: '', plex_token: '', host: '0.0.0.0', port: 32401, pin_rules: '', force_direct_play: true, mediainfo_enabled: false, plex_direct_host: '', helper_url: '', helper_token: '', emby_url: '', emby_apikey: '', use_emby: true, use_ffprobe: true, ffprobe_path_map: '/Volumes/data=/media', ffprobe_timeout: 40, overwrite_streams: true, only_missing: true, concurrency: 3, sections: '', webhook_enabled: false, dedup_window: 300, forward_episodes: 5 };
+const config = reactive({ ...defaults, ...props.initialConfig });
+const savedBaseline = ref(JSON.parse(JSON.stringify(defaults)));
+
+watch(() => props.initialConfig, value => { if (!value || typeof value !== 'object' || !Object.keys(value).length) return; Object.assign(config, value); snapshotBaseline(); }, { deep: true });
+watch(activeTab, () => emit('layout', layoutRequest));
+
+const selectedSections = computed({ get: () => config.sections ? String(config.sections).split(',').map(item => item.trim()).filter(Boolean) : [], set: value => { config.sections = (value || []).join(','); } });
+function normalizeValue(value) { if (Array.isArray(value)) return JSON.stringify([...value].sort()); if (value === undefined || value === null) return ''; return String(value) }
+const changedCount = computed(() => Object.keys(defaults).filter(key => normalizeValue(config[key]) !== normalizeValue(savedBaseline.value[key])).length);
+const triggerText = computed(() => !config.mediainfo_enabled ? '未启用' : '当前条目 + 后续集');
+const helperStatusText = computed(() => { if (helperInfo.value || status.value.helper_health_ok === true) return '正常'; if (status.value.helper_health_ok === false) return `异常（连续 ${status.value.helper_health_failures || 1} 次）`; return config.helper_url ? '等待检查' : '未配置' });
+const lastRunText = computed(() => lastPlay.value ? fmtTime(lastPlay.value.ts || lastPlay.value.time || lastPlay.value.created_at) : '暂无');
+const lastWriteText = computed(() => lastPlay.value ? `${lastPlay.value.written_ok || 0} 成功 / ${lastPlay.value.write_failed || 0} 失败` : '暂无');
+
+const DashboardRow = defineComponent({ props: { icon: String, label: String, value: [String, Number] }, setup(rowProps) { return () => h('div', { class: 'ptb-dashboard-row' }, [h(VIconComponent, { icon: rowProps.icon, size: 18 }), h('span', rowProps.label), h('strong', String(rowProps.value ?? '-'))]) } });
+const StatCard = defineComponent({ props: { label: String, value: [String, Number] }, setup(cardProps) { return () => h('div', { class: 'ptb-stat' }, [h('div', { class: 'ptb-stat-value' }, String(cardProps.value ?? '-')), h('div', { class: 'ptb-stat-label' }, cardProps.label)]) } });
+const TargetFields = defineComponent({ setup() { return () => h('div', { class: 'ptb-target-grid' }, [h(VSelectComponent, { modelValue: scrapeSection.value, 'onUpdate:modelValue': value => { scrapeSection.value = value; }, items: sectionOptions.value, itemTitle: 'title', itemValue: 'value', label: '目标 Plex 媒体库', variant: 'outlined', density: 'compact', hideDetails: 'auto', loading: loadingSections.value }), h(VTextFieldComponent, { modelValue: scrapeLimit.value, 'onUpdate:modelValue': value => { scrapeLimit.value = Number(value) || 0; }, type: 'number', min: 0, label: '限制条数（0=不限）', variant: 'outlined', density: 'compact', hideDetails: 'auto' })]) } });
+
+function statusLabel(value) { return ({ written: '已写入', resolved: '已解析', unresolved: '未命中', write_failed: '写入失败', busy: 'Plex忙' })[value] || (value || '-') }
+function statusColor(value) { return ({ written: 'success', resolved: 'teal', unresolved: 'orange', write_failed: 'error', busy: 'warning' })[value] || 'grey' }
+function fmtTime(value) { if (!value) return '-'; const numeric = Number(value); const date = Number.isFinite(numeric) ? new Date(numeric > 100000000000 ? numeric : numeric * 1000) : new Date(value); if (Number.isNaN(date.getTime())) return String(value); const pad = item => String(item).padStart(2, '0'); return `${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}` }
+function showMatching(type, text) { matchingResult.value = { type, text }; }
+function showScraping(type, text) { scrapingResult.value = { type, text }; }
+
+async function loadSections() { loadingSections.value = true; try { const response = await getPluginApi(props.api, 'sections'); if (!response?.success) throw new Error(response?.error || '获取媒体库失败'); sectionOptions.value = (response.sections || []).map(item => ({ title: `${item.title}（${item.type}）`, value: String(item.key) })); } catch (exception) { error.value = String(exception); } finally { loadingSections.value = false; } }
+async function loadRuntimeData() { loadingRuntime.value = true; try { const [runtimeStatus, result] = await Promise.all([getPluginApi(props.api, 'status'), getPluginApi(props.api, 'result')]); status.value = runtimeStatus || {}; lastPlay.value = result?.last_play_result || null; history.value = Array.isArray(result?.play_history) ? result.play_history : []; } catch (exception) { error.value = String(exception); } finally { loadingRuntime.value = false; } }
+function snapshotBaseline() { savedBaseline.value = JSON.parse(JSON.stringify({ ...defaults, ...config })); }
+async function loadConfig() { try { const response = await getPluginApi(props.api, 'config'); const persisted = response?.data || response; if (persisted && typeof persisted === 'object') Object.assign(config, persisted); snapshotBaseline(); } catch (exception) { error.value = String(exception); } }
+async function checkHelper() { checking.value = true; helperInfo.value = ''; try { const response = await getPluginApi(props.api, 'helper_check'); if (!response?.success) throw new Error(response?.error || 'helper 检查失败'); helperInfo.value = response?.dbinfo?.db_path || '已连接'; } catch (exception) { error.value = String(exception); } finally { checking.value = false; } }
+async function clearData(target) { clearing.value = target === 'play_history' ? 'history' : 'last'; try { const response = await postPluginApi(props.api, 'clear_completion_data', { target }); if (!response?.success) throw new Error(response?.error || '清理失败'); if (target === 'play_history') history.value = []; else lastPlay.value = null; expanded.value = -1; } catch (exception) { error.value = String(exception); } finally { clearing.value = ''; } }
+
+async function doUnmatch(dryRun) { if (!scrapeSection.value) return showMatching('warning', '请先选择目标媒体库'); if (!dryRun && !window.confirm('确认对该媒体库执行取消匹配？条目将被打回未匹配并按当前 NFO 代理重读。')) return; busyKey.value = dryRun ? 'unmatch_preview' : 'unmatch_run'; matchingResult.value = null; try { const response = await postPluginApi(props.api, 'unmatch', { section: scrapeSection.value, dry_run: dryRun, rematch: true, limit: Number(scrapeLimit.value) || 0 }); if (!response?.success) throw new Error(response?.error || '操作失败'); showMatching(dryRun ? 'info' : 'success', dryRun ? `预览：该库共 ${response.total_items} 个条目，将影响 ${response.will_affect} 个` : `已取消匹配 ${response.unmatched} 个，刷新重读 ${response.refreshed} 个，失败 ${response.failed} 个`); } catch (exception) { showMatching('error', String(exception)); } finally { busyKey.value = ''; } }
+async function doScanCover() { if (!scrapeSection.value) return showScraping('warning', '请先选择目标媒体库'); busyKey.value = 'scan_cover'; try { const response = await postPluginApi(props.api, 'scan_cover', { section: scrapeSection.value }); if (!response?.success) throw new Error(response?.error || '扫描失败'); const list = (response.missing || []).slice(0, 20).map(item => `· ${item.title}（${item.reason}）`).join('\n'); showScraping('info', `已检查 ${response.checked} 个条目，缺封面 ${response.total} 个${list ? '：\n' + list : ''}`); } catch (exception) { showScraping('error', String(exception)); } finally { busyKey.value = ''; } }
+async function doScrape(dryRun) { if (!scrapeSection.value) return showScraping('warning', '请先选择目标媒体库'); if (!dryRun && !window.confirm('确认对缺封面条目执行 MoviePilot 刮削？将生成 NFO+封面文件。')) return; busyKey.value = dryRun ? 'scrape_preview' : 'scrape_run'; try { const response = await postPluginApi(props.api, 'scrape', { section: scrapeSection.value, dry_run: dryRun, limit: Number(scrapeLimit.value) || 0, unmatch_after: false }); if (!response?.success) throw new Error(response?.error || '刮削失败'); const list = (response.targets || []).slice(0, 20).map(item => `· ${item.title} → ${item.dir}`).join('\n'); showScraping(dryRun ? 'info' : 'success', dryRun ? `待刮削 ${response.candidates} 个目录${list ? '：\n' + list : ''}` : `刮削成功 ${response.scraped} 个，已刷新 ${response.refreshed || 0} 个，失败 ${response.failed} 个`); } catch (exception) { showScraping('error', String(exception)); } finally { busyKey.value = ''; } }
+async function doFixPoster(dryRun) { if (!scrapeSection.value) return showScraping('warning', '请先选择目标媒体库'); if (!dryRun && !window.confirm('确认为缺 poster.jpg 的条目执行补全？剧集优先复制季内海报，其余从 TMDB 下载。')) return; busyKey.value = dryRun ? 'poster_preview' : 'poster_run'; try { const response = await postPluginApi(props.api, 'fix_poster', { section: scrapeSection.value, dry_run: dryRun, limit: Number(scrapeLimit.value) || 0 }); if (!response?.success) throw new Error(response?.error || '操作失败'); const list = (response.targets || []).slice(0, 20).map(item => `· ${item.title} → ${item.dir}`).join('\n'); showScraping(dryRun ? 'info' : (response.failed ? 'warning' : 'success'), dryRun ? `已检查 ${response.checked} 个条目，缺 poster ${response.candidates} 个${list ? '：\n' + list : ''}` : `补全成功 ${response.fixed} 个（已刷新 ${response.refreshed}），失败 ${response.failed} 个`); } catch (exception) { showScraping('error', String(exception)); } finally { busyKey.value = ''; } }
+
+async function doMergeScan() { busyKey.value = 'merge_scan'; mergeResult.value = null; mergeGroups.value = []; mergeScanned.value = false; try { const response = await getPluginApi(props.api, 'merge_scan'); if (!response?.success) throw new Error(response?.error || '扫描失败'); mergeGroups.value = response.groups || []; mergeScanned.value = true; if (!mergeGroups.value.length) mergeResult.value = { type: 'success', text: '未发现重复条目' }; } catch (exception) { mergeResult.value = { type: 'error', text: String(exception) }; } finally { busyKey.value = ''; } }
+async function doMergeExecute() { if (!mergeGroups.value.length) return; if (!window.confirm(`确认合并 ${mergeGroups.value.length} 组重复条目？每组保留集数最多的条目，其余并入。`)) return; busyKey.value = 'merge_run'; mergeResult.value = null; try { const merges = mergeGroups.value.map(group => { const sorted = [...group.items].sort((a, b) => (Number(b.leaf_count) || 0) - (Number(a.leaf_count) || 0)); return { primary: sorted[0].rating_key, others: sorted.slice(1).map(item => item.rating_key) } }); const response = await postPluginApi(props.api, 'merge_execute', { merges }); if (!response?.success) throw new Error(response?.error || '合并失败'); const msg = `合并成功 ${response.merged} 组${response.failed?.length ? '，失败 ' + response.failed.length + ' 组' : ''}`; busyKey.value = ''; await doMergeScan(); mergeResult.value = { type: 'success', text: msg + '（已重新扫描）' }; } catch (exception) { mergeResult.value = { type: 'error', text: String(exception) }; } finally { busyKey.value = ''; } }
+
+async function saveConfig() { const payload = { ...config }; error.value = ''; saving.value = true; try { const response = await postPluginApi(props.api, 'config', payload); if (!response?.success) throw new Error(response?.message || response?.error || '配置保存失败'); const verify = await getPluginApi(props.api, 'config'); const persisted = verify?.data || verify; if (persisted && typeof persisted === 'object') Object.assign(config, persisted); snapshotBaseline(); saveMessage.value = '配置已保存并生效'; saveSnackbar.value = true; } catch (exception) { error.value = exception?.message || String(exception); } finally { saving.value = false; } }
+onMounted(async () => { emit('layout', layoutRequest); await loadConfig(); await loadRuntimeData(); if (config.plex_token && (config.plex_direct_host || config.plex_host)) loadSections(); });
+
+return (_ctx, _cache) => {
+  const _component_VIcon = _resolveComponent("VIcon");
+  const _component_VAvatar = _resolveComponent("VAvatar");
+  const _component_VCardTitle = _resolveComponent("VCardTitle");
+  const _component_VCardSubtitle = _resolveComponent("VCardSubtitle");
+  const _component_VBtn = _resolveComponent("VBtn");
+  const _component_VCardItem = _resolveComponent("VCardItem");
+  const _component_VDivider = _resolveComponent("VDivider");
+  const _component_VListItemTitle = _resolveComponent("VListItemTitle");
+  const _component_VChip = _resolveComponent("VChip");
+  const _component_VListItem = _resolveComponent("VListItem");
+  const _component_VList = _resolveComponent("VList");
+  const _component_VAlert = _resolveComponent("VAlert");
+  const _component_VSwitch = _resolveComponent("VSwitch");
+  const _component_VCol = _resolveComponent("VCol");
+  const _component_VTextField = _resolveComponent("VTextField");
+  const _component_VTextarea = _resolveComponent("VTextarea");
+  const _component_VRow = _resolveComponent("VRow");
+  const _component_VSelect = _resolveComponent("VSelect");
+  const _component_VSpacer = _resolveComponent("VSpacer");
+  const _component_VTable = _resolveComponent("VTable");
+  const _component_VCard = _resolveComponent("VCard");
+  const _component_VBottomSheet = _resolveComponent("VBottomSheet");
+  const _component_VSnackbar = _resolveComponent("VSnackbar");
+
+  return (_openBlock(), _createElementBlock("div", _hoisted_1, [
+    _createVNode(_component_VCard, {
+      flat: "",
+      class: "ptb-card"
+    }, {
+      default: _withCtx(() => [
+        _createVNode(_component_VCardItem, { class: "ptb-header" }, {
+          prepend: _withCtx(() => [
+            _createVNode(_component_VAvatar, {
+              color: "primary",
+              variant: "tonal",
+              size: "44",
+              rounded: "lg"
+            }, {
+              default: _withCtx(() => [
+                _createVNode(_component_VIcon, {
+                  icon: "mdi-plex",
+                  size: "24"
+                })
+              ]),
+              _: 1
+            })
+          ]),
+          append: _withCtx(() => [
+            _createElementVNode("div", _hoisted_2, [
+              (changedCount.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_3, [
+                    _createVNode(_component_VIcon, {
+                      icon: "mdi-circle-medium",
+                      color: "warning",
+                      size: "18"
+                    }),
+                    _createElementVNode("span", _hoisted_4, _toDisplayString(changedCount.value) + " 项待保存", 1)
+                  ]))
+                : _createCommentVNode("", true),
+              (changedCount.value)
+                ? (_openBlock(), _createBlock(_component_VBtn, {
+                    key: 1,
+                    color: "primary",
+                    variant: "flat",
+                    size: "small",
+                    "prepend-icon": "mdi-content-save",
+                    rounded: "lg",
+                    loading: saving.value,
+                    onClick: saveConfig
+                  }, {
+                    default: _withCtx(() => [...(_cache[38] || (_cache[38] = [
+                      _createTextVNode("保存修改", -1)
+                    ]))]),
+                    _: 1
+                  }, 8, ["loading"]))
+                : _createCommentVNode("", true),
+              _createVNode(_component_VBtn, {
+                icon: "mdi-close",
+                variant: "text",
+                size: "small",
+                onClick: _cache[0] || (_cache[0] = $event => (emit('close')))
+              })
+            ])
+          ]),
+          default: _withCtx(() => [
+            _createVNode(_component_VCardTitle, { class: "text-h6 ptb-header-title" }, {
+              default: _withCtx(() => [...(_cache[37] || (_cache[37] = [
+                _createTextVNode("PLEX 工具箱", -1)
+              ]))]),
+              _: 1
+            }),
+            _createVNode(_component_VCardSubtitle, { class: "text-caption ptb-header-subtitle" }, {
+              default: _withCtx(() => [
+                _createTextVNode(_toDisplayString(currentTab.value.desc), 1)
+              ]),
+              _: 1
+            })
+          ]),
+          _: 1
+        }),
+        _createVNode(_component_VDivider),
+        _createElementVNode("div", _hoisted_5, [
+          _createElementVNode("nav", _hoisted_6, [
+            _createVNode(_component_VList, {
+              density: "comfortable",
+              nav: "",
+              class: "py-2"
+            }, {
+              default: _withCtx(() => [
+                (_openBlock(), _createElementBlock(_Fragment, null, _renderList(tabs, (item) => {
+                  return _createVNode(_component_VListItem, {
+                    key: item.key,
+                    active: activeTab.value === item.key,
+                    color: "primary",
+                    rounded: "lg",
+                    class: "ptb-nav-item",
+                    onClick: $event => (activeTab.value = item.key)
+                  }, _createSlots({
+                    prepend: _withCtx(() => [
+                      _createVNode(_component_VIcon, {
+                        icon: item.icon
+                      }, null, 8, ["icon"])
+                    ]),
+                    default: _withCtx(() => [
+                      _createVNode(_component_VListItemTitle, null, {
+                        default: _withCtx(() => [
+                          _createTextVNode(_toDisplayString(item.title), 1)
+                        ]),
+                        _: 2
+                      }, 1024)
+                    ]),
+                    _: 2
+                  }, [
+                    (item.key === 'records' && history.value.length)
+                      ? {
+                          name: "append",
+                          fn: _withCtx(() => [
+                            _createVNode(_component_VChip, {
+                              size: "x-small",
+                              variant: "tonal"
+                            }, {
+                              default: _withCtx(() => [
+                                _createTextVNode(_toDisplayString(history.value.length), 1)
+                              ]),
+                              _: 1
+                            })
+                          ]),
+                          key: "0"
+                        }
+                      : undefined
+                  ]), 1032, ["active", "onClick"])
+                }), 64))
+              ]),
+              _: 1
+            })
+          ]),
+          _createElementVNode("section", _hoisted_7, [
+            _createElementVNode("div", _hoisted_8, [
+              _createElementVNode("div", _hoisted_9, [
+                _createElementVNode("div", _hoisted_10, _toDisplayString(currentTab.value.title), 1),
+                _createElementVNode("div", _hoisted_11, _toDisplayString(currentTab.value.desc), 1)
+              ]),
+              _createVNode(_component_VBtn, {
+                icon: "mdi-menu-down",
+                variant: "tonal",
+                size: "small",
+                onClick: _cache[1] || (_cache[1] = $event => (mobileTabSheet.value = true))
+              })
+            ]),
+            (error.value)
+              ? (_openBlock(), _createBlock(_component_VAlert, {
+                  key: 0,
+                  type: "error",
+                  variant: "tonal",
+                  density: "compact",
+                  class: "ptb-error-alert ma-3 mb-0 text-caption",
+                  closable: "",
+                  "onClick:close": _cache[2] || (_cache[2] = $event => (error.value = ''))
+                }, {
+                  default: _withCtx(() => [
+                    _createTextVNode(_toDisplayString(error.value), 1)
+                  ]),
+                  _: 1
+                }))
+              : _createCommentVNode("", true),
+            _createElementVNode("div", _hoisted_12, [
+              _createElementVNode("div", _hoisted_13, [
+                _withDirectives(_createElementVNode("div", _hoisted_14, [
+                  _cache[39] || (_cache[39] = _createElementVNode("div", { class: "ptb-section-title" }, "302 反向代理", -1)),
+                  _createVNode(_component_VRow, null, {
+                    default: _withCtx(() => [
+                      _createVNode(_component_VCol, { cols: "12" }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSwitch, {
+                            modelValue: config.proxy_enabled,
+                            "onUpdate:modelValue": _cache[3] || (_cache[3] = $event => ((config.proxy_enabled) = $event)),
+                            color: "primary",
+                            "hide-details": "",
+                            inset: "",
+                            label: "启用 302 反向代理"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "8"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.plex_host,
+                            "onUpdate:modelValue": _cache[4] || (_cache[4] = $event => ((config.plex_host) = $event)),
+                            label: "Plex 服务器地址",
+                            placeholder: "http://192.168.0.122:32400",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "4"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.plex_token,
+                            "onUpdate:modelValue": _cache[5] || (_cache[5] = $event => ((config.plex_token) = $event)),
+                            label: "X-Plex-Token",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "6"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.host,
+                            "onUpdate:modelValue": _cache[6] || (_cache[6] = $event => ((config.host) = $event)),
+                            label: "代理监听地址",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "6"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.port,
+                            "onUpdate:modelValue": _cache[7] || (_cache[7] = $event => ((config.port) = $event)),
+                            modelModifiers: { number: true },
+                            type: "number",
+                            label: "代理监听端口",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, { cols: "12" }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSwitch, {
+                            modelValue: config.force_direct_play,
+                            "onUpdate:modelValue": _cache[8] || (_cache[8] = $event => ((config.force_direct_play) = $event)),
+                            color: "primary",
+                            "hide-details": "",
+                            inset: "",
+                            label: "强制 DirectPlay（避免转码使直链失效）"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, { cols: "12" }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextarea, {
+                            modelValue: config.pin_rules,
+                            "onUpdate:modelValue": _cache[9] || (_cache[9] = $event => ((config.pin_rules) = $event)),
+                            label: "顶置路径规则（每行：路径前缀 => 目标URL）",
+                            variant: "outlined",
+                            density: "compact",
+                            rows: "3",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      })
+                    ]),
+                    _: 1
+                  })
+                ], 512), [
+                  [_vShow, activeTab.value === 'proxy']
+                ]),
+                _withDirectives(_createElementVNode("div", _hoisted_15, [
+                  _cache[42] || (_cache[42] = _createElementVNode("div", { class: "ptb-section-title" }, "STRM 媒体流信息补全", -1)),
+                  _createVNode(_component_VAlert, {
+                    type: "info",
+                    variant: "tonal",
+                    density: "compact",
+                    class: "mb-3 text-caption"
+                  }, {
+                    default: _withCtx(() => [
+                      _cache[40] || (_cache[40] = _createTextVNode("点击播放时先补全当前条目及设置的后续集，最多等待 3 秒后自动放行播放。需先在 Plex 主机部署 helper 写库服务；没有 Emby 时可直接用 ffprobe 探测 STRM 内的 302 直链。", -1)),
+                      _createElementVNode("a", {
+                        href: helperDocUrl,
+                        target: "_blank",
+                        rel: "noopener",
+                        class: "ptb-doc-link"
+                      }, "查看部署说明")
+                    ]),
+                    _: 1
+                  }),
+                  _createVNode(_component_VRow, null, {
+                    default: _withCtx(() => [
+                      _createVNode(_component_VCol, { cols: "12" }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSwitch, {
+                            modelValue: config.mediainfo_enabled,
+                            "onUpdate:modelValue": _cache[10] || (_cache[10] = $event => ((config.mediainfo_enabled) = $event)),
+                            color: "primary",
+                            "hide-details": "",
+                            inset: "",
+                            label: "启用媒体信息补全"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "8"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.plex_direct_host,
+                            "onUpdate:modelValue": _cache[11] || (_cache[11] = $event => ((config.plex_direct_host) = $event)),
+                            label: "Plex 直连地址（写库/枚举用）",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "4"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VBtn, {
+                            color: "info",
+                            variant: "tonal",
+                            size: "small",
+                            loading: checking.value,
+                            "prepend-icon": "mdi-lan-connect",
+                            onClick: checkHelper
+                          }, {
+                            default: _withCtx(() => [...(_cache[41] || (_cache[41] = [
+                              _createTextVNode("检查 helper", -1)
+                            ]))]),
+                            _: 1
+                          }, 8, ["loading"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "8"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.helper_url,
+                            "onUpdate:modelValue": _cache[12] || (_cache[12] = $event => ((config.helper_url) = $event)),
+                            label: "helper 地址",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "4"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.helper_token,
+                            "onUpdate:modelValue": _cache[13] || (_cache[13] = $event => ((config.helper_token) = $event)),
+                            label: "helper Token",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "6"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSwitch, {
+                            modelValue: config.use_emby,
+                            "onUpdate:modelValue": _cache[14] || (_cache[14] = $event => ((config.use_emby) = $event)),
+                            color: "primary",
+                            "hide-details": "",
+                            inset: "",
+                            label: "数据源 Emby MediaStreams"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "8"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.emby_url,
+                            "onUpdate:modelValue": _cache[15] || (_cache[15] = $event => ((config.emby_url) = $event)),
+                            label: "Emby 地址",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "4"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.emby_apikey,
+                            "onUpdate:modelValue": _cache[16] || (_cache[16] = $event => ((config.emby_apikey) = $event)),
+                            label: "Emby API Key",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, { cols: "12" }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSwitch, {
+                            modelValue: config.use_ffprobe,
+                            "onUpdate:modelValue": _cache[17] || (_cache[17] = $event => ((config.use_ffprobe) = $event)),
+                            color: "primary",
+                            "hide-details": "",
+                            inset: "",
+                            label: "启用 ffprobe（无 Emby 或 Emby 未命中时读取 STRM 302 直链）"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "8"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.ffprobe_path_map,
+                            "onUpdate:modelValue": _cache[18] || (_cache[18] = $event => ((config.ffprobe_path_map) = $event)),
+                            label: "Plex 路径 → MoviePilot 容器路径映射",
+                            placeholder: "/Volumes/data=/media",
+                            hint: "每行一条，支持 =、=> 或分号分隔；Plex 主机路径在左，MP 容器路径在右",
+                            "persistent-hint": "",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "4"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.ffprobe_timeout,
+                            "onUpdate:modelValue": _cache[19] || (_cache[19] = $event => ((config.ffprobe_timeout) = $event)),
+                            modelModifiers: { number: true },
+                            type: "number",
+                            min: "1",
+                            max: "300",
+                            label: "ffprobe 超时（秒）",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "8"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSelect, {
+                            modelValue: selectedSections.value,
+                            "onUpdate:modelValue": _cache[20] || (_cache[20] = $event => ((selectedSections).value = $event)),
+                            items: sectionOptions.value,
+                            "item-title": "title",
+                            "item-value": "value",
+                            label: "要补全的 Plex 媒体库",
+                            variant: "outlined",
+                            density: "compact",
+                            multiple: "",
+                            chips: "",
+                            "closable-chips": "",
+                            "hide-details": "auto",
+                            loading: loadingSections.value
+                          }, {
+                            "append-inner": _withCtx(() => [
+                              _createVNode(_component_VBtn, {
+                                icon: "mdi-refresh",
+                                size: "x-small",
+                                variant: "text",
+                                onClick: _withModifiers(loadSections, ["stop"])
+                              })
+                            ]),
+                            _: 1
+                          }, 8, ["modelValue", "items", "loading"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "4"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.concurrency,
+                            "onUpdate:modelValue": _cache[21] || (_cache[21] = $event => ((config.concurrency) = $event)),
+                            modelModifiers: { number: true },
+                            type: "number",
+                            min: "1",
+                            max: "10",
+                            label: "探测并发数",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "6"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSwitch, {
+                            modelValue: config.only_missing,
+                            "onUpdate:modelValue": _cache[22] || (_cache[22] = $event => ((config.only_missing) = $event)),
+                            color: "primary",
+                            "hide-details": "",
+                            inset: "",
+                            label: "仅处理缺失媒体信息的条目"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "6"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSwitch, {
+                            modelValue: config.overwrite_streams,
+                            "onUpdate:modelValue": _cache[23] || (_cache[23] = $event => ((config.overwrite_streams) = $event)),
+                            color: "primary",
+                            "hide-details": "",
+                            inset: "",
+                            label: "写入前清空旧流"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "6"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VSwitch, {
+                            modelValue: config.webhook_enabled,
+                            "onUpdate:modelValue": _cache[24] || (_cache[24] = $event => ((config.webhook_enabled) = $event)),
+                            color: "primary",
+                            "hide-details": "",
+                            inset: "",
+                            label: "启用 Plex Webhook 触发"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "6"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.dedup_window,
+                            "onUpdate:modelValue": _cache[25] || (_cache[25] = $event => ((config.dedup_window) = $event)),
+                            modelModifiers: { number: true },
+                            type: "number",
+                            min: "0",
+                            label: "播前同条目去重窗口（秒）",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      }),
+                      _createVNode(_component_VCol, {
+                        cols: "12",
+                        md: "6"
+                      }, {
+                        default: _withCtx(() => [
+                          _createVNode(_component_VTextField, {
+                            modelValue: config.forward_episodes,
+                            "onUpdate:modelValue": _cache[26] || (_cache[26] = $event => ((config.forward_episodes) = $event)),
+                            modelModifiers: { number: true },
+                            type: "number",
+                            min: "0",
+                            label: "剧集向后预取集数",
+                            variant: "outlined",
+                            density: "compact",
+                            "hide-details": "auto"
+                          }, null, 8, ["modelValue"])
+                        ]),
+                        _: 1
+                      })
+                    ]),
+                    _: 1
+                  }),
+                  (helperInfo.value)
+                    ? (_openBlock(), _createBlock(_component_VAlert, {
+                        key: 0,
+                        type: "success",
+                        variant: "tonal",
+                        density: "compact",
+                        class: "mt-2 text-caption"
+                      }, {
+                        default: _withCtx(() => [
+                          _createTextVNode("helper 正常，数据库：" + _toDisplayString(helperInfo.value), 1)
+                        ]),
+                        _: 1
+                      }))
+                    : _createCommentVNode("", true)
+                ], 512), [
+                  [_vShow, activeTab.value === 'mediainfo']
+                ]),
+                _withDirectives(_createElementVNode("div", _hoisted_16, [
+                  _createElementVNode("div", _hoisted_17, [
+                    _cache[43] || (_cache[43] = _createElementVNode("div", { class: "ptb-section-title mb-0" }, "补全记录", -1)),
+                    _createVNode(_component_VSpacer),
+                    _createVNode(_component_VBtn, {
+                      icon: "mdi-refresh",
+                      variant: "text",
+                      size: "small",
+                      loading: loadingRuntime.value,
+                      onClick: loadRuntimeData
+                    }, null, 8, ["loading"])
+                  ]),
+                  _createElementVNode("div", _hoisted_18, [
+                    _cache[45] || (_cache[45] = _createElementVNode("div", { class: "ptb-block-title" }, "最近一次补全", -1)),
+                    _createVNode(_component_VSpacer),
+                    (lastPlay.value)
+                      ? (_openBlock(), _createBlock(_component_VBtn, {
+                          key: 0,
+                          color: "grey",
+                          variant: "text",
+                          size: "x-small",
+                          "prepend-icon": "mdi-broom",
+                          loading: clearing.value === 'last',
+                          onClick: _cache[27] || (_cache[27] = $event => (clearData('last_play_result')))
+                        }, {
+                          default: _withCtx(() => [...(_cache[44] || (_cache[44] = [
+                            _createTextVNode("清理", -1)
+                          ]))]),
+                          _: 1
+                        }, 8, ["loading"]))
+                      : _createCommentVNode("", true)
+                  ]),
+                  (lastPlay.value)
+                    ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
+                        (lastPlay.value.label)
+                          ? (_openBlock(), _createElementBlock("div", _hoisted_19, _toDisplayString(lastPlay.value.label), 1))
+                          : _createCommentVNode("", true),
+                        _createElementVNode("div", _hoisted_20, [
+                          _createVNode(_unref(StatCard), {
+                            label: "本次条目",
+                            value: lastPlay.value.strm_parts
+                          }, null, 8, ["value"]),
+                          _createVNode(_unref(StatCard), {
+                            label: "已解析",
+                            value: lastPlay.value.resolved
+                          }, null, 8, ["value"]),
+                          _createVNode(_unref(StatCard), {
+                            label: "Emby 命中",
+                            value: lastPlay.value.emby_hits
+                          }, null, 8, ["value"]),
+                          _createVNode(_unref(StatCard), {
+                            label: "ffprobe 命中",
+                            value: lastPlay.value.ffprobe_hits
+                          }, null, 8, ["value"]),
+                          _createVNode(_unref(StatCard), {
+                            label: "写入成功",
+                            value: lastPlay.value.written_ok
+                          }, null, 8, ["value"]),
+                          _createVNode(_unref(StatCard), {
+                            label: "写入失败",
+                            value: lastPlay.value.write_failed
+                          }, null, 8, ["value"])
+                        ]),
+                        (lastPlay.value.items?.length)
+                          ? (_openBlock(), _createBlock(_component_VTable, {
+                              key: 1,
+                              density: "compact",
+                              class: "ptb-history"
+                            }, {
+                              default: _withCtx(() => [
+                                _cache[46] || (_cache[46] = _createElementVNode("thead", null, [
+                                  _createElementVNode("tr", null, [
+                                    _createElementVNode("th", null, "条目"),
+                                    _createElementVNode("th", null, "状态")
+                                  ])
+                                ], -1)),
+                                _createElementVNode("tbody", null, [
+                                  (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(lastPlay.value.items, (item, index) => {
+                                    return (_openBlock(), _createElementBlock("tr", { key: index }, [
+                                      _createElementVNode("td", _hoisted_21, _toDisplayString(item.label || ('part ' + item.part_id)), 1),
+                                      _createElementVNode("td", null, [
+                                        _createVNode(_component_VChip, {
+                                          color: statusColor(item.status),
+                                          size: "x-small",
+                                          variant: "tonal"
+                                        }, {
+                                          default: _withCtx(() => [
+                                            _createTextVNode(_toDisplayString(statusLabel(item.status)), 1)
+                                          ]),
+                                          _: 2
+                                        }, 1032, ["color"]),
+                                        (item.error)
+                                          ? (_openBlock(), _createElementBlock("span", _hoisted_22, _toDisplayString(item.error), 1))
+                                          : _createCommentVNode("", true)
+                                      ])
+                                    ]))
+                                  }), 128))
+                                ])
+                              ]),
+                              _: 1
+                            }))
+                          : _createCommentVNode("", true)
+                      ], 64))
+                    : (_openBlock(), _createBlock(_component_VAlert, {
+                        key: 1,
+                        type: "info",
+                        variant: "tonal",
+                        density: "compact",
+                        class: "text-caption"
+                      }, {
+                        default: _withCtx(() => [...(_cache[47] || (_cache[47] = [
+                          _createTextVNode("暂无补全记录。", -1)
+                        ]))]),
+                        _: 1
+                      })),
+                  (lastPlay.value?.helper_busy)
+                    ? (_openBlock(), _createBlock(_component_VAlert, {
+                        key: 2,
+                        type: "warning",
+                        variant: "tonal",
+                        density: "compact",
+                        class: "mt-3 text-caption"
+                      }, {
+                        default: _withCtx(() => [...(_cache[48] || (_cache[48] = [
+                          _createTextVNode("Plex 当前繁忙，本次未写入。", -1)
+                        ]))]),
+                        _: 1
+                      }))
+                    : _createCommentVNode("", true),
+                  _createVNode(_component_VDivider, { class: "my-4" }),
+                  _createElementVNode("div", _hoisted_23, [
+                    _createElementVNode("div", _hoisted_24, "补全历史（最近 " + _toDisplayString(history.value.length) + " 条）", 1),
+                    _createVNode(_component_VSpacer),
+                    (history.value.length)
+                      ? (_openBlock(), _createBlock(_component_VBtn, {
+                          key: 0,
+                          color: "grey",
+                          variant: "text",
+                          size: "x-small",
+                          "prepend-icon": "mdi-broom",
+                          loading: clearing.value === 'history',
+                          onClick: _cache[28] || (_cache[28] = $event => (clearData('play_history')))
+                        }, {
+                          default: _withCtx(() => [...(_cache[49] || (_cache[49] = [
+                            _createTextVNode("清空历史", -1)
+                          ]))]),
+                          _: 1
+                        }, 8, ["loading"]))
+                      : _createCommentVNode("", true)
+                  ]),
+                  (history.value.length)
+                    ? (_openBlock(), _createBlock(_component_VTable, {
+                        key: 3,
+                        density: "compact",
+                        class: "ptb-history"
+                      }, {
+                        default: _withCtx(() => [
+                          _cache[50] || (_cache[50] = _createElementVNode("thead", null, [
+                            _createElementVNode("tr", null, [
+                              _createElementVNode("th", null, "时间"),
+                              _createElementVNode("th", null, "条目"),
+                              _createElementVNode("th", null, "结果")
+                            ])
+                          ], -1)),
+                          _createElementVNode("tbody", null, [
+                            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(history.value, (row, index) => {
+                              return (_openBlock(), _createElementBlock(_Fragment, { key: index }, [
+                                _createElementVNode("tr", {
+                                  class: "ptb-row",
+                                  onClick: $event => (expanded.value = expanded.value === index ? -1 : index)
+                                }, [
+                                  _createElementVNode("td", null, _toDisplayString(fmtTime(row.ts || row.time || row.created_at)), 1),
+                                  _createElementVNode("td", null, _toDisplayString(row.label || '-'), 1),
+                                  _createElementVNode("td", null, _toDisplayString(row.written_ok || 0) + " 成功 / " + _toDisplayString(row.write_failed || 0) + " 失败", 1)
+                                ], 8, _hoisted_25),
+                                (expanded.value === index)
+                                  ? (_openBlock(), _createElementBlock("tr", _hoisted_26, [
+                                      _createElementVNode("td", _hoisted_27, [
+                                        (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(row.items || [], (item, itemIndex) => {
+                                          return (_openBlock(), _createElementBlock("div", {
+                                            key: itemIndex,
+                                            class: "py-1"
+                                          }, [
+                                            _createVNode(_component_VChip, {
+                                              color: statusColor(item.status),
+                                              size: "x-small",
+                                              variant: "tonal"
+                                            }, {
+                                              default: _withCtx(() => [
+                                                _createTextVNode(_toDisplayString(statusLabel(item.status)), 1)
+                                              ]),
+                                              _: 2
+                                            }, 1032, ["color"]),
+                                            _createElementVNode("span", _hoisted_28, _toDisplayString(item.label || item.part_id), 1)
+                                          ]))
+                                        }), 128))
+                                      ])
+                                    ]))
+                                  : _createCommentVNode("", true)
+                              ], 64))
+                            }), 128))
+                          ])
+                        ]),
+                        _: 1
+                      }))
+                    : (_openBlock(), _createBlock(_component_VAlert, {
+                        key: 4,
+                        type: "info",
+                        variant: "tonal",
+                        density: "compact",
+                        class: "text-caption"
+                      }, {
+                        default: _withCtx(() => [...(_cache[51] || (_cache[51] = [
+                          _createTextVNode("暂无历史记录。", -1)
+                        ]))]),
+                        _: 1
+                      }))
+                ], 512), [
+                  [_vShow, activeTab.value === 'records']
+                ]),
+                _withDirectives(_createElementVNode("div", _hoisted_29, [
+                  _cache[55] || (_cache[55] = _createElementVNode("div", { class: "ptb-section-title" }, "目录匹配", -1)),
+                  _createVNode(_component_VAlert, {
+                    type: "info",
+                    variant: "tonal",
+                    density: "compact",
+                    class: "mb-3 text-caption"
+                  }, {
+                    default: _withCtx(() => [...(_cache[52] || (_cache[52] = [
+                      _createTextVNode("取消匹配后，条目会按当前 NFO 代理重读。建议先预览影响。", -1)
+                    ]))]),
+                    _: 1
+                  }),
+                  _createVNode(_unref(TargetFields)),
+                  _createElementVNode("div", _hoisted_30, [
+                    _createVNode(_component_VBtn, {
+                      color: "info",
+                      variant: "tonal",
+                      size: "small",
+                      loading: busyKey.value === 'unmatch_preview',
+                      disabled: !!busyKey.value,
+                      "prepend-icon": "mdi-magnify",
+                      onClick: _cache[29] || (_cache[29] = $event => (doUnmatch(true)))
+                    }, {
+                      default: _withCtx(() => [...(_cache[53] || (_cache[53] = [
+                        _createTextVNode("预览影响", -1)
+                      ]))]),
+                      _: 1
+                    }, 8, ["loading", "disabled"]),
+                    _createVNode(_component_VBtn, {
+                      color: "warning",
+                      variant: "flat",
+                      size: "small",
+                      loading: busyKey.value === 'unmatch_run',
+                      disabled: !!busyKey.value,
+                      "prepend-icon": "mdi-link-off",
+                      onClick: _cache[30] || (_cache[30] = $event => (doUnmatch(false)))
+                    }, {
+                      default: _withCtx(() => [...(_cache[54] || (_cache[54] = [
+                        _createTextVNode("执行取消匹配", -1)
+                      ]))]),
+                      _: 1
+                    }, 8, ["loading", "disabled"])
+                  ]),
+                  (matchingResult.value)
+                    ? (_openBlock(), _createBlock(_component_VAlert, {
+                        key: 0,
+                        type: matchingResult.value.type,
+                        variant: "tonal",
+                        density: "compact",
+                        class: "mt-4 text-caption",
+                        style: {"white-space":"pre-wrap"}
+                      }, {
+                        default: _withCtx(() => [
+                          _createTextVNode(_toDisplayString(matchingResult.value.text), 1)
+                        ]),
+                        _: 1
+                      }, 8, ["type"]))
+                    : _createCommentVNode("", true)
+                ], 512), [
+                  [_vShow, activeTab.value === 'matching']
+                ]),
+                _withDirectives(_createElementVNode("div", _hoisted_31, [
+                  _cache[62] || (_cache[62] = _createElementVNode("div", { class: "ptb-section-title" }, "刮削与海报", -1)),
+                  _createVNode(_component_VAlert, {
+                    type: "info",
+                    variant: "tonal",
+                    density: "compact",
+                    class: "mb-3 text-caption"
+                  }, {
+                    default: _withCtx(() => [...(_cache[56] || (_cache[56] = [
+                      _createTextVNode("扫描缺封面条目并交给 MoviePilot 生成 NFO/封面，或精准补全缺失 poster.jpg。", -1)
+                    ]))]),
+                    _: 1
+                  }),
+                  _createVNode(_unref(TargetFields)),
+                  _cache[63] || (_cache[63] = _createElementVNode("div", { class: "ptb-subsection-title mt-4" }, "缺封面刮削", -1)),
+                  _createElementVNode("div", _hoisted_32, [
+                    _createVNode(_component_VBtn, {
+                      color: "info",
+                      variant: "tonal",
+                      size: "small",
+                      loading: busyKey.value === 'scan_cover',
+                      disabled: !!busyKey.value,
+                      "prepend-icon": "mdi-image-off-outline",
+                      onClick: doScanCover
+                    }, {
+                      default: _withCtx(() => [...(_cache[57] || (_cache[57] = [
+                        _createTextVNode("扫描缺封面", -1)
+                      ]))]),
+                      _: 1
+                    }, 8, ["loading", "disabled"]),
+                    _createVNode(_component_VBtn, {
+                      color: "info",
+                      variant: "tonal",
+                      size: "small",
+                      loading: busyKey.value === 'scrape_preview',
+                      disabled: !!busyKey.value,
+                      "prepend-icon": "mdi-magnify",
+                      onClick: _cache[31] || (_cache[31] = $event => (doScrape(true)))
+                    }, {
+                      default: _withCtx(() => [...(_cache[58] || (_cache[58] = [
+                        _createTextVNode("预览刮削目录", -1)
+                      ]))]),
+                      _: 1
+                    }, 8, ["loading", "disabled"]),
+                    _createVNode(_component_VBtn, {
+                      color: "success",
+                      variant: "flat",
+                      size: "small",
+                      loading: busyKey.value === 'scrape_run',
+                      disabled: !!busyKey.value,
+                      "prepend-icon": "mdi-auto-fix",
+                      onClick: _cache[32] || (_cache[32] = $event => (doScrape(false)))
+                    }, {
+                      default: _withCtx(() => [...(_cache[59] || (_cache[59] = [
+                        _createTextVNode("执行刮削", -1)
+                      ]))]),
+                      _: 1
+                    }, 8, ["loading", "disabled"])
+                  ]),
+                  _createVNode(_component_VDivider, { class: "my-4" }),
+                  _cache[64] || (_cache[64] = _createElementVNode("div", { class: "ptb-subsection-title" }, "缺 poster.jpg 精准补全", -1)),
+                  _createElementVNode("div", _hoisted_33, [
+                    _createVNode(_component_VBtn, {
+                      color: "info",
+                      variant: "tonal",
+                      size: "small",
+                      loading: busyKey.value === 'poster_preview',
+                      disabled: !!busyKey.value,
+                      "prepend-icon": "mdi-magnify",
+                      onClick: _cache[33] || (_cache[33] = $event => (doFixPoster(true)))
+                    }, {
+                      default: _withCtx(() => [...(_cache[60] || (_cache[60] = [
+                        _createTextVNode("预览缺 poster", -1)
+                      ]))]),
+                      _: 1
+                    }, 8, ["loading", "disabled"]),
+                    _createVNode(_component_VBtn, {
+                      color: "success",
+                      variant: "flat",
+                      size: "small",
+                      loading: busyKey.value === 'poster_run',
+                      disabled: !!busyKey.value,
+                      "prepend-icon": "mdi-image-plus",
+                      onClick: _cache[34] || (_cache[34] = $event => (doFixPoster(false)))
+                    }, {
+                      default: _withCtx(() => [...(_cache[61] || (_cache[61] = [
+                        _createTextVNode("执行补全", -1)
+                      ]))]),
+                      _: 1
+                    }, 8, ["loading", "disabled"])
+                  ]),
+                  (scrapingResult.value)
+                    ? (_openBlock(), _createBlock(_component_VAlert, {
+                        key: 0,
+                        type: scrapingResult.value.type,
+                        variant: "tonal",
+                        density: "compact",
+                        class: "mt-4 text-caption",
+                        style: {"white-space":"pre-wrap"}
+                      }, {
+                        default: _withCtx(() => [
+                          _createTextVNode(_toDisplayString(scrapingResult.value.text), 1)
+                        ]),
+                        _: 1
+                      }, 8, ["type"]))
+                    : _createCommentVNode("", true)
+                ], 512), [
+                  [_vShow, activeTab.value === 'scraping']
+                ]),
+                _withDirectives(_createElementVNode("div", _hoisted_34, [
+                  _cache[69] || (_cache[69] = _createElementVNode("div", { class: "ptb-section-title" }, "合并重复条目", -1)),
+                  _createVNode(_component_VAlert, {
+                    type: "info",
+                    variant: "tonal",
+                    density: "compact",
+                    class: "mb-3 text-caption"
+                  }, {
+                    default: _withCtx(() => [...(_cache[65] || (_cache[65] = [
+                      _createTextVNode("扫描 Plex 全部剧集/电影库中 tmdb id 相同的重复条目，合并为一个（保留集数最多的条目作主）。", -1)
+                    ]))]),
+                    _: 1
+                  }),
+                  _createElementVNode("div", _hoisted_35, [
+                    _createVNode(_component_VBtn, {
+                      color: "info",
+                      variant: "tonal",
+                      size: "small",
+                      loading: busyKey.value === 'merge_scan',
+                      disabled: !!busyKey.value,
+                      "prepend-icon": "mdi-magnify",
+                      onClick: doMergeScan
+                    }, {
+                      default: _withCtx(() => [...(_cache[66] || (_cache[66] = [
+                        _createTextVNode("扫描重复", -1)
+                      ]))]),
+                      _: 1
+                    }, 8, ["loading", "disabled"]),
+                    (mergeGroups.value.length)
+                      ? (_openBlock(), _createBlock(_component_VBtn, {
+                          key: 0,
+                          color: "success",
+                          variant: "flat",
+                          size: "small",
+                          loading: busyKey.value === 'merge_run',
+                          disabled: !!busyKey.value,
+                          "prepend-icon": "mdi-call-merge",
+                          onClick: doMergeExecute
+                        }, {
+                          default: _withCtx(() => [
+                            _createTextVNode("合并全部（" + _toDisplayString(mergeGroups.value.length) + " 组）", 1)
+                          ]),
+                          _: 1
+                        }, 8, ["loading", "disabled"]))
+                      : _createCommentVNode("", true)
+                  ]),
+                  (mergeGroups.value.length)
+                    ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
+                        _createElementVNode("div", _hoisted_36, "共 " + _toDisplayString(mergeGroups.value.length) + " 组重复", 1),
+                        _createVNode(_component_VTable, {
+                          density: "compact",
+                          class: "ptb-history"
+                        }, {
+                          default: _withCtx(() => [
+                            _cache[67] || (_cache[67] = _createElementVNode("thead", null, [
+                              _createElementVNode("tr", null, [
+                                _createElementVNode("th", null, "剧集 / 电影"),
+                                _createElementVNode("th", null, "TMDB"),
+                                _createElementVNode("th", null, "重复条目")
+                              ])
+                            ], -1)),
+                            _createElementVNode("tbody", null, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(mergeGroups.value, (group, gi) => {
+                                return (_openBlock(), _createElementBlock("tr", { key: gi }, [
+                                  _createElementVNode("td", _hoisted_37, _toDisplayString(group.title), 1),
+                                  _createElementVNode("td", _hoisted_38, _toDisplayString(group.guid_id), 1),
+                                  _createElementVNode("td", _hoisted_39, [
+                                    (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(group.items, (item, ii) => {
+                                      return (_openBlock(), _createElementBlock("div", {
+                                        key: ii,
+                                        class: _normalizeClass({ 'font-weight-bold': ii === 0 })
+                                      }, " [" + _toDisplayString(item.section_title) + "] " + _toDisplayString(item.title) + "（" + _toDisplayString(item.year) + "）— " + _toDisplayString(item.leaf_count) + " 集 ", 3))
+                                    }), 128))
+                                  ])
+                                ]))
+                              }), 128))
+                            ])
+                          ]),
+                          _: 1
+                        })
+                      ], 64))
+                    : (mergeScanned.value)
+                      ? (_openBlock(), _createBlock(_component_VAlert, {
+                          key: 1,
+                          type: "success",
+                          variant: "tonal",
+                          density: "compact",
+                          class: "mt-2 text-caption"
+                        }, {
+                          default: _withCtx(() => [...(_cache[68] || (_cache[68] = [
+                            _createTextVNode("未发现重复条目。", -1)
+                          ]))]),
+                          _: 1
+                        }))
+                      : _createCommentVNode("", true),
+                  (mergeResult.value)
+                    ? (_openBlock(), _createBlock(_component_VAlert, {
+                        key: 2,
+                        type: mergeResult.value.type,
+                        variant: "tonal",
+                        density: "compact",
+                        class: "mt-4 text-caption",
+                        style: {"white-space":"pre-wrap"}
+                      }, {
+                        default: _withCtx(() => [
+                          _createTextVNode(_toDisplayString(mergeResult.value.text), 1)
+                        ]),
+                        _: 1
+                      }, 8, ["type"]))
+                    : _createCommentVNode("", true)
+                ], 512), [
+                  [_vShow, activeTab.value === 'merge']
+                ])
+              ]),
+              _createElementVNode("aside", _hoisted_40, [
+                _createElementVNode("section", null, [
+                  _createElementVNode("div", _hoisted_41, [
+                    _createVNode(_component_VIcon, {
+                      icon: "mdi-clock-outline",
+                      color: "primary",
+                      size: "20"
+                    }),
+                    _cache[70] || (_cache[70] = _createTextVNode("运行节奏", -1))
+                  ]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-motion-play-outline",
+                    label: "播前补全",
+                    value: triggerText.value
+                  }, null, 8, ["value"]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-skip-forward-outline",
+                    label: "播前追加",
+                    value: `后 ${config.forward_episodes || 0} 集`
+                  }, null, 8, ["value"]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-timer-outline",
+                    label: "去重窗口",
+                    value: `${config.dedup_window || 0} 秒`
+                  }, null, 8, ["value"]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-heart-pulse",
+                    label: "Helper 检查",
+                    value: "每 5 分钟"
+                  })
+                ]),
+                _createVNode(_component_VDivider, { class: "my-3" }),
+                _createElementVNode("section", null, [
+                  _createElementVNode("div", _hoisted_42, [
+                    _createVNode(_component_VIcon, {
+                      icon: "mdi-chart-box-outline",
+                      color: "primary",
+                      size: "20"
+                    }),
+                    _cache[71] || (_cache[71] = _createTextVNode("运行概况", -1))
+                  ]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-swap-horizontal-bold",
+                    label: "代理服务",
+                    value: status.value.proxy_running ? '运行中' : '未运行'
+                  }, null, 8, ["value"]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-lan-connect",
+                    label: "Helper",
+                    value: helperStatusText.value
+                  }, null, 8, ["value"]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-database-search-outline",
+                    label: "媒体数据源",
+                    value: config.use_emby && config.emby_url && config.emby_apikey && config.use_ffprobe ? 'Emby → ffprobe' : (config.use_emby && config.emby_url && config.emby_apikey ? 'Emby' : (config.use_ffprobe ? 'ffprobe' : '未启用'))
+                  }, null, 8, ["value"]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-history",
+                    label: "最近补全",
+                    value: lastRunText.value
+                  }, null, 8, ["value"]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-database-check-outline",
+                    label: "最近写入",
+                    value: lastWriteText.value
+                  }, null, 8, ["value"]),
+                  _createVNode(_unref(DashboardRow), {
+                    icon: "mdi-folder-multiple-outline",
+                    label: "补全媒体库",
+                    value: `${selectedSections.value.length} 个`
+                  }, null, 8, ["value"])
+                ])
+              ])
+            ])
+          ])
+        ])
+      ]),
+      _: 1
+    }),
+    _createVNode(_component_VBottomSheet, {
+      modelValue: mobileTabSheet.value,
+      "onUpdate:modelValue": _cache[35] || (_cache[35] = $event => ((mobileTabSheet).value = $event))
+    }, {
+      default: _withCtx(() => [
+        _createVNode(_component_VCard, null, {
+          default: _withCtx(() => [
+            _createVNode(_component_VCardTitle, { class: "text-subtitle-1" }, {
+              default: _withCtx(() => [...(_cache[72] || (_cache[72] = [
+                _createTextVNode("选择功能", -1)
+              ]))]),
+              _: 1
+            }),
+            _createVNode(_component_VList, { nav: "" }, {
+              default: _withCtx(() => [
+                (_openBlock(), _createElementBlock(_Fragment, null, _renderList(tabs, (item) => {
+                  return _createVNode(_component_VListItem, {
+                    key: item.key,
+                    active: activeTab.value === item.key,
+                    title: item.title,
+                    subtitle: item.desc,
+                    onClick: $event => {activeTab.value = item.key; mobileTabSheet.value = false;}
+                  }, {
+                    prepend: _withCtx(() => [
+                      _createVNode(_component_VIcon, {
+                        icon: item.icon
+                      }, null, 8, ["icon"])
+                    ]),
+                    _: 2
+                  }, 1032, ["active", "title", "subtitle", "onClick"])
+                }), 64))
+              ]),
+              _: 1
+            })
+          ]),
+          _: 1
+        })
+      ]),
+      _: 1
+    }, 8, ["modelValue"]),
+    _createVNode(_component_VSnackbar, {
+      modelValue: saveSnackbar.value,
+      "onUpdate:modelValue": _cache[36] || (_cache[36] = $event => ((saveSnackbar).value = $event)),
+      color: "success",
+      location: "top",
+      timeout: 2200
+    }, {
+      default: _withCtx(() => [
+        _createTextVNode(_toDisplayString(saveMessage.value), 1)
+      ]),
+      _: 1
+    }, 8, ["modelValue"])
+  ]))
+}
+}
+
+};
+const Config = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-d649379b"]]);
+
+export { Config as default };

--- a/plugins.v3/plextoolbox/dist/assets/__federation_expose_Page-B9Nx4FsP.js
+++ b/plugins.v3/plextoolbox/dist/assets/__federation_expose_Page-B9Nx4FsP.js
@@ -1,0 +1,55 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import Config from './__federation_expose_Config-DKmiLaR4.js';
+
+const {openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
+
+
+const {onMounted,ref} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'Page',
+  props: {
+  api: { type: Object, default: () => ({}) },
+},
+  emits: ['action', 'close', 'layout'],
+  setup(__props, { emit: __emit }) {
+
+const props = __props;
+
+const emit = __emit;
+const initialConfig = ref({});
+
+function unwrap(response) {
+  const body = response?.data ?? response ?? {};
+  return body?.data ?? body
+}
+
+async function onSave(payload) {
+  await props.api.post('plugin/PlexToolbox/config', payload);
+  emit('action');
+}
+
+onMounted(async () => {
+  try {
+    const response = await props.api.get('plugin/PlexToolbox/config');
+    initialConfig.value = unwrap(response) || {};
+  } catch (error) {
+    console.error('读取 PLEX 工具箱配置失败', error);
+  }
+});
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(Config, {
+    "initial-config": initialConfig.value,
+    api: __props.api,
+    onSave: onSave,
+    onClose: _cache[0] || (_cache[0] = $event => (emit('close'))),
+    onLayout: _cache[1] || (_cache[1] = payload => emit('layout', payload))
+  }, null, 8, ["initial-config", "api"]))
+}
+}
+
+};
+
+export { _sfc_main as default };

--- a/plugins.v3/plextoolbox/dist/assets/__federation_fn_import-JrT3xvdd.js
+++ b/plugins.v3/plextoolbox/dist/assets/__federation_fn_import-JrT3xvdd.js
@@ -1,0 +1,418 @@
+const buildIdentifier = "[0-9A-Za-z-]+";
+const build = `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))`;
+const numericIdentifier = "0|[1-9]\\d*";
+const numericIdentifierLoose = "[0-9]+";
+const nonNumericIdentifier = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
+const preReleaseIdentifierLoose = `(?:${numericIdentifierLoose}|${nonNumericIdentifier})`;
+const preReleaseLoose = `(?:-?(${preReleaseIdentifierLoose}(?:\\.${preReleaseIdentifierLoose})*))`;
+const preReleaseIdentifier = `(?:${numericIdentifier}|${nonNumericIdentifier})`;
+const preRelease = `(?:-(${preReleaseIdentifier}(?:\\.${preReleaseIdentifier})*))`;
+const xRangeIdentifier = `${numericIdentifier}|x|X|\\*`;
+const xRangePlain = `[v=\\s]*(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:${preRelease})?${build}?)?)?`;
+const hyphenRange = `^\\s*(${xRangePlain})\\s+-\\s+(${xRangePlain})\\s*$`;
+const mainVersionLoose = `(${numericIdentifierLoose})\\.(${numericIdentifierLoose})\\.(${numericIdentifierLoose})`;
+const loosePlain = `[v=\\s]*${mainVersionLoose}${preReleaseLoose}?${build}?`;
+const gtlt = "((?:<|>)?=?)";
+const comparatorTrim = `(\\s*)${gtlt}\\s*(${loosePlain}|${xRangePlain})`;
+const loneTilde = "(?:~>?)";
+const tildeTrim = `(\\s*)${loneTilde}\\s+`;
+const loneCaret = "(?:\\^)";
+const caretTrim = `(\\s*)${loneCaret}\\s+`;
+const star = "(<|>)?=?\\s*\\*";
+const caret = `^${loneCaret}${xRangePlain}$`;
+const mainVersion = `(${numericIdentifier})\\.(${numericIdentifier})\\.(${numericIdentifier})`;
+const fullPlain = `v?${mainVersion}${preRelease}?${build}?`;
+const tilde = `^${loneTilde}${xRangePlain}$`;
+const xRange = `^${gtlt}\\s*${xRangePlain}$`;
+const comparator = `^${gtlt}\\s*(${fullPlain})$|^$`;
+const gte0 = "^\\s*>=\\s*0.0.0\\s*$";
+function parseRegex(source) {
+  return new RegExp(source);
+}
+function isXVersion(version) {
+  return !version || version.toLowerCase() === "x" || version === "*";
+}
+function pipe(...fns) {
+  return (x) => {
+    return fns.reduce((v, f) => f(v), x);
+  };
+}
+function extractComparator(comparatorString) {
+  return comparatorString.match(parseRegex(comparator));
+}
+function combineVersion(major, minor, patch, preRelease2) {
+  const mainVersion2 = `${major}.${minor}.${patch}`;
+  if (preRelease2) {
+    return `${mainVersion2}-${preRelease2}`;
+  }
+  return mainVersion2;
+}
+function parseHyphen(range) {
+  return range.replace(
+    parseRegex(hyphenRange),
+    (_range, from, fromMajor, fromMinor, fromPatch, _fromPreRelease, _fromBuild, to, toMajor, toMinor, toPatch, toPreRelease) => {
+      if (isXVersion(fromMajor)) {
+        from = "";
+      } else if (isXVersion(fromMinor)) {
+        from = `>=${fromMajor}.0.0`;
+      } else if (isXVersion(fromPatch)) {
+        from = `>=${fromMajor}.${fromMinor}.0`;
+      } else {
+        from = `>=${from}`;
+      }
+      if (isXVersion(toMajor)) {
+        to = "";
+      } else if (isXVersion(toMinor)) {
+        to = `<${+toMajor + 1}.0.0-0`;
+      } else if (isXVersion(toPatch)) {
+        to = `<${toMajor}.${+toMinor + 1}.0-0`;
+      } else if (toPreRelease) {
+        to = `<=${toMajor}.${toMinor}.${toPatch}-${toPreRelease}`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }
+  );
+}
+function parseComparatorTrim(range) {
+  return range.replace(parseRegex(comparatorTrim), "$1$2$3");
+}
+function parseTildeTrim(range) {
+  return range.replace(parseRegex(tildeTrim), "$1~");
+}
+function parseCaretTrim(range) {
+  return range.replace(parseRegex(caretTrim), "$1^");
+}
+function parseCarets(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(caret),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          if (major === "0") {
+            return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+          } else {
+            return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`;
+          }
+        } else if (preRelease2) {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+            }
+          } else {
+            return `>=${major}.${minor}.${patch}-${preRelease2} <${+major + 1}.0.0-0`;
+          }
+        } else {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+            }
+          }
+          return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`;
+        }
+      }
+    );
+  }).join(" ");
+}
+function parseTildes(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(tilde),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+        } else if (preRelease2) {
+          return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+      }
+    );
+  }).join(" ");
+}
+function parseXRanges(range) {
+  return range.split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.trim().replace(
+      parseRegex(xRange),
+      (ret, gtlt2, major, minor, patch, preRelease2) => {
+        const isXMajor = isXVersion(major);
+        const isXMinor = isXMajor || isXVersion(minor);
+        const isXPatch = isXMinor || isXVersion(patch);
+        if (gtlt2 === "=" && isXPatch) {
+          gtlt2 = "";
+        }
+        preRelease2 = "";
+        if (isXMajor) {
+          if (gtlt2 === ">" || gtlt2 === "<") {
+            return "<0.0.0-0";
+          } else {
+            return "*";
+          }
+        } else if (gtlt2 && isXPatch) {
+          if (isXMinor) {
+            minor = 0;
+          }
+          patch = 0;
+          if (gtlt2 === ">") {
+            gtlt2 = ">=";
+            if (isXMinor) {
+              major = +major + 1;
+              minor = 0;
+              patch = 0;
+            } else {
+              minor = +minor + 1;
+              patch = 0;
+            }
+          } else if (gtlt2 === "<=") {
+            gtlt2 = "<";
+            if (isXMinor) {
+              major = +major + 1;
+            } else {
+              minor = +minor + 1;
+            }
+          }
+          if (gtlt2 === "<") {
+            preRelease2 = "-0";
+          }
+          return `${gtlt2 + major}.${minor}.${patch}${preRelease2}`;
+        } else if (isXMinor) {
+          return `>=${major}.0.0${preRelease2} <${+major + 1}.0.0-0`;
+        } else if (isXPatch) {
+          return `>=${major}.${minor}.0${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return ret;
+      }
+    );
+  }).join(" ");
+}
+function parseStar(range) {
+  return range.trim().replace(parseRegex(star), "");
+}
+function parseGTE0(comparatorString) {
+  return comparatorString.trim().replace(parseRegex(gte0), "");
+}
+function compareAtom(rangeAtom, versionAtom) {
+  rangeAtom = +rangeAtom || rangeAtom;
+  versionAtom = +versionAtom || versionAtom;
+  if (rangeAtom > versionAtom) {
+    return 1;
+  }
+  if (rangeAtom === versionAtom) {
+    return 0;
+  }
+  return -1;
+}
+function comparePreRelease(rangeAtom, versionAtom) {
+  const { preRelease: rangePreRelease } = rangeAtom;
+  const { preRelease: versionPreRelease } = versionAtom;
+  if (rangePreRelease === void 0 && !!versionPreRelease) {
+    return 1;
+  }
+  if (!!rangePreRelease && versionPreRelease === void 0) {
+    return -1;
+  }
+  if (rangePreRelease === void 0 && versionPreRelease === void 0) {
+    return 0;
+  }
+  for (let i = 0, n = rangePreRelease.length; i <= n; i++) {
+    const rangeElement = rangePreRelease[i];
+    const versionElement = versionPreRelease[i];
+    if (rangeElement === versionElement) {
+      continue;
+    }
+    if (rangeElement === void 0 && versionElement === void 0) {
+      return 0;
+    }
+    if (!rangeElement) {
+      return 1;
+    }
+    if (!versionElement) {
+      return -1;
+    }
+    return compareAtom(rangeElement, versionElement);
+  }
+  return 0;
+}
+function compareVersion(rangeAtom, versionAtom) {
+  return compareAtom(rangeAtom.major, versionAtom.major) || compareAtom(rangeAtom.minor, versionAtom.minor) || compareAtom(rangeAtom.patch, versionAtom.patch) || comparePreRelease(rangeAtom, versionAtom);
+}
+function eq(rangeAtom, versionAtom) {
+  return rangeAtom.version === versionAtom.version;
+}
+function compare(rangeAtom, versionAtom) {
+  switch (rangeAtom.operator) {
+    case "":
+    case "=":
+      return eq(rangeAtom, versionAtom);
+    case ">":
+      return compareVersion(rangeAtom, versionAtom) < 0;
+    case ">=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0;
+    case "<":
+      return compareVersion(rangeAtom, versionAtom) > 0;
+    case "<=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0;
+    case void 0: {
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+function parseComparatorString(range) {
+  return pipe(
+    parseCarets,
+    parseTildes,
+    parseXRanges,
+    parseStar
+  )(range);
+}
+function parseRange(range) {
+  return pipe(
+    parseHyphen,
+    parseComparatorTrim,
+    parseTildeTrim,
+    parseCaretTrim
+  )(range.trim()).split(/\s+/).join(" ");
+}
+function satisfy(version, range) {
+  if (!version) {
+    return false;
+  }
+  const parsedRange = parseRange(range);
+  const parsedComparator = parsedRange.split(" ").map((rangeVersion) => parseComparatorString(rangeVersion)).join(" ");
+  const comparators = parsedComparator.split(/\s+/).map((comparator2) => parseGTE0(comparator2));
+  const extractedVersion = extractComparator(version);
+  if (!extractedVersion) {
+    return false;
+  }
+  const [
+    ,
+    versionOperator,
+    ,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    versionPreRelease
+  ] = extractedVersion;
+  const versionAtom = {
+    version: combineVersion(
+      versionMajor,
+      versionMinor,
+      versionPatch,
+      versionPreRelease
+    ),
+    major: versionMajor,
+    minor: versionMinor,
+    patch: versionPatch,
+    preRelease: versionPreRelease == null ? void 0 : versionPreRelease.split(".")
+  };
+  for (const comparator2 of comparators) {
+    const extractedComparator = extractComparator(comparator2);
+    if (!extractedComparator) {
+      return false;
+    }
+    const [
+      ,
+      rangeOperator,
+      ,
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease
+    ] = extractedComparator;
+    const rangeAtom = {
+      operator: rangeOperator,
+      version: combineVersion(
+        rangeMajor,
+        rangeMinor,
+        rangePatch,
+        rangePreRelease
+      ),
+      major: rangeMajor,
+      minor: rangeMinor,
+      patch: rangePatch,
+      preRelease: rangePreRelease == null ? void 0 : rangePreRelease.split(".")
+    };
+    if (!compare(rangeAtom, versionAtom)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// eslint-disable-next-line no-undef
+const moduleMap = {};
+const moduleCache = Object.create(null);
+async function importShared(name, shareScope = 'default') {
+  return moduleCache[name]
+    ? new Promise((r) => r(moduleCache[name]))
+    : (await getSharedFromRuntime(name, shareScope)) || getSharedFromLocal(name)
+}
+async function getSharedFromRuntime(name, shareScope) {
+  let module = null;
+  if (globalThis?.__federation_shared__?.[shareScope]?.[name]) {
+    const versionObj = globalThis.__federation_shared__[shareScope][name];
+    const requiredVersion = moduleMap[name]?.requiredVersion;
+    const hasRequiredVersion = !!requiredVersion;
+    if (hasRequiredVersion) {
+      const versionKey = Object.keys(versionObj).find((version) =>
+        satisfy(version, requiredVersion)
+      );
+      if (versionKey) {
+        const versionValue = versionObj[versionKey];
+        module = await (await versionValue.get())();
+      } else {
+        console.log(
+          `provider support ${name}(${versionKey}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})`
+        );
+      }
+    } else {
+      const versionKey = Object.keys(versionObj)[0];
+      const versionValue = versionObj[versionKey];
+      module = await (await versionValue.get())();
+    }
+  }
+  if (module) {
+    return flattenModule(module, name)
+  }
+}
+async function getSharedFromLocal(name) {
+  if (moduleMap[name]?.import) {
+    let module = await (await moduleMap[name].get())();
+    return flattenModule(module, name)
+  } else {
+    console.error(
+      `consumer config import=false,so cant use callback shared module`
+    );
+  }
+}
+function flattenModule(module, name) {
+  // use a shared module which export default a function will getting error 'TypeError: xxx is not a function'
+  if (typeof module.default === 'function') {
+    Object.keys(module).forEach((key) => {
+      if (key !== 'default') {
+        module.default[key] = module[key];
+      }
+    });
+    moduleCache[name] = module.default;
+    return module.default
+  }
+  if (module.default) module = Object.assign({}, module.default, module);
+  moduleCache[name] = module;
+  return module
+}
+
+export { importShared, getSharedFromLocal as importSharedLocal, getSharedFromRuntime as importSharedRuntime };

--- a/plugins.v3/plextoolbox/dist/assets/index-iTW_u30D.js
+++ b/plugins.v3/plextoolbox/dist/assets/index-iTW_u30D.js
@@ -1,0 +1,40 @@
+import './__federation_expose_Config-DKmiLaR4.js';
+import './__federation_expose_Page-B9Nx4FsP.js';
+
+true&&(function polyfill() {
+  const relList = document.createElement("link").relList;
+  if (relList && relList.supports && relList.supports("modulepreload")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === "LINK" && node.rel === "modulepreload")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity) fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === "use-credentials")
+      fetchOpts.credentials = "include";
+    else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
+    else fetchOpts.credentials = "same-origin";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+}());

--- a/plugins.v3/plextoolbox/dist/assets/remoteEntry.js
+++ b/plugins.v3/plextoolbox/dist/assets/remoteEntry.js
@@ -1,0 +1,84 @@
+const currentImports = {};
+      const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
+      let moduleMap = {
+"./Page":()=>{
+      dynamicLoadingCss(["__federation_expose_Config-C2jHLi0c.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-B9Nx4FsP.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+"./Config":()=>{
+      dynamicLoadingCss(["__federation_expose_Config-C2jHLi0c.css"], false, './Config');
+      return __federation_import('./__federation_expose_Config-DKmiLaR4.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
+      const seen = {};
+      const dynamicLoadingCss = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
+        const metaUrl = import.meta.url;
+        if (typeof metaUrl === 'undefined') {
+          console.warn('The remote style takes effect only when the build.target option in the vite.config.ts file is higher than that of "es2020".');
+          return;
+        }
+
+        const curUrl = metaUrl.substring(0, metaUrl.lastIndexOf('remoteEntry.js'));
+        const base = '/';
+        'assets';
+
+        cssFilePaths.forEach(cssPath => {
+         let href = '';
+         const baseUrl = base || curUrl;
+         if (baseUrl) {
+           const trimmer = {
+             trailing: (path) => (path.endsWith('/') ? path.slice(0, -1) : path),
+             leading: (path) => (path.startsWith('/') ? path.slice(1) : path)
+           };
+           const isAbsoluteUrl = (url) => url.startsWith('http') || url.startsWith('//');
+
+           const cleanBaseUrl = trimmer.trailing(baseUrl);
+           const cleanCssPath = trimmer.leading(cssPath);
+           const cleanCurUrl = trimmer.trailing(curUrl);
+
+           if (isAbsoluteUrl(baseUrl)) {
+             href = [cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
+           } else {
+            if (cleanCurUrl.includes(cleanBaseUrl)) {
+              href = [cleanCurUrl, cleanCssPath].filter(Boolean).join('/');
+            } else {
+              href = [cleanCurUrl + cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
+            }
+           }
+         } else {
+           href = cssPath;
+         }
+
+          if (dontAppendStylesToHead) {
+            const key = 'css__PlexToolbox__' + exposeItemName;
+            window[key] = window[key] || [];
+            window[key].push(href);
+            return;
+          }
+
+          if (href in seen) return;
+          seen[href] = true;
+
+          const element = document.createElement('link');
+          element.rel = 'stylesheet';
+          element.href = href;
+          document.head.appendChild(element);
+        });
+      };
+      async function __federation_import(name) {
+        currentImports[name] ??= import(name);
+        return currentImports[name]
+      }      const get =(module) => {
+        if(!moduleMap[module]) throw new Error('Can not find remote module ' + module)
+        return moduleMap[module]();
+      };
+      const init =(shareScope) => {
+        globalThis.__federation_shared__= globalThis.__federation_shared__|| {};
+        Object.entries(shareScope).forEach(([key, value]) => {
+          for (const [versionKey, versionValue] of Object.entries(value)) {
+            const scope = versionValue.scope || 'default';
+            globalThis.__federation_shared__[scope] = globalThis.__federation_shared__[scope] || {};
+            const shared= globalThis.__federation_shared__[scope];
+            (shared[key] = shared[key]||{})[versionKey] = versionValue;
+          }
+        });
+      };
+
+export { dynamicLoadingCss, get, init };

--- a/plugins.v3/plextoolbox/dist/index.html
+++ b/plugins.v3/plextoolbox/dist/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PlexToolbox</title>
+    <script type="module" crossorigin src="/assets/index-iTW_u30D.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/__federation_fn_import-JrT3xvdd.js">
+    <link rel="modulepreload" crossorigin href="/assets/__federation_expose_Config-DKmiLaR4.js">
+    <link rel="modulepreload" crossorigin href="/assets/__federation_expose_Page-B9Nx4FsP.js">
+    <link rel="stylesheet" crossorigin href="/assets/__federation_expose_Config-C2jHLi0c.css">
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/plugins.v3/plextoolbox/emby_client.py
+++ b/plugins.v3/plextoolbox/emby_client.py
@@ -1,0 +1,279 @@
+"""Emby API 轻封装：按文件名/路径查询条目的 MediaStreams 媒体流信息。"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, List, Optional
+from urllib.parse import quote, urlparse, unquote
+
+from httpx import Client
+
+from app.sdk.logging import logger
+
+
+class EmbyClient:
+    """封装 Emby 只读查询，用于按文件名匹配媒体并取其媒体流信息作为数据源。"""
+
+    def __init__(self, base_url: str, api_key: str, timeout: float = 30.0) -> None:
+        """
+        初始化 Emby 客户端。
+
+        :param base_url: Emby 根地址，如 http://192.168.0.121:8096
+        :param api_key: Emby API Key
+        :param timeout: 请求超时秒数
+        """
+        self._base = base_url.rstrip("/")
+        self._key = api_key
+        self._timeout = timeout
+        self._user_id: Optional[str] = None
+
+    def _get(self, path: str, params: Optional[Dict[str, str]] = None) -> Optional[dict]:
+        """
+        发起 GET 请求并解析 JSON。
+
+        :param path: 相对路径
+        :param params: 查询参数
+        :return: JSON 或 None
+        """
+        query = {"api_key": self._key}
+        if params:
+            query.update(params)
+        qs = "&".join(f"{k}={quote(str(v), safe='')}" for k, v in query.items())
+        url = f"{self._base}{path}?{qs}"
+        try:
+            with Client(timeout=self._timeout) as client:
+                resp = client.get(url, headers={"Accept": "application/json"})
+                if resp.status_code == 200:
+                    return resp.json()
+                logger.warning("Emby API %s 返回 %s", path, resp.status_code)
+        except Exception as e:
+            logger.warning("Emby API 请求失败 %s: %s", path, e)
+        return None
+
+    def find_streams_by_name(self, file_name: str) -> Optional[Dict[str, Any]]:
+        """
+        搜索 Emby 条目并返回其归一化媒体流信息。
+
+        匹配策略（按优先级）：
+        1) 从 STRM 路径的 {tmdb-xxxxx} 提取 TMDB ID，用 AnyProviderIdEquals 精确定位
+           条目/剧集，再用文件名匹配具体 MediaSource（Emby 条目名是媒体标题而非
+           带画质标签的长文件名，用文件名当 SearchTerm 往往搜不到）。
+        2) 回退：用文件名 stem 作为 SearchTerm 模糊搜。
+
+        :param file_name: STRM 文件路径或文件名
+        :return: 归一化后的媒体信息 dict，未找到返回 None
+        """
+        stem = os.path.splitext(os.path.basename(file_name))[0]
+        if not stem:
+            return None
+
+        # 策略1：按路径中的 TMDB ID 精确搜
+        tmdb_id = self._extract_tmdb_id(file_name)
+        if tmdb_id:
+            data = self._get(
+                "/Items",
+                {
+                    "Recursive": "true",
+                    "AnyProviderIdEquals": f"tmdb.{tmdb_id}",
+                    "Fields": "MediaSources,Path",
+                    "Limit": "50",
+                },
+            )
+            if data:
+                items = data.get("Items", []) or []
+                # 剧集的 tmdb-xxxx 是剧集级 ID，命中的是 Series 条目，本身没有
+                # MediaSources，真正带流信息的是每个 Episode。需下钻到集再按文件名匹配。
+                series_items = [
+                    it for it in items
+                    if it.get("Type") == "Series" or not (it.get("MediaSources"))
+                ]
+                for it in series_items:
+                    sid = it.get("Id")
+                    if not sid:
+                        continue
+                    info = self._find_in_series_episodes(sid, stem)
+                    if info:
+                        return info
+                # 电影/直接可播放条目：先按文件名精确匹配 MediaSource
+                for item in items:
+                    info = self._extract_from_item(item, stem)
+                    if info:
+                        return info
+                # 电影通常单条单源，未精确匹配上时取第一个有流的源兜底
+                for item in items:
+                    for src in item.get("MediaSources") or []:
+                        info = self._normalize_source(src)
+                        if info:
+                            return info
+
+        # 策略2：回退到文件名 SearchTerm 模糊搜
+        data = self._get(
+            "/Items",
+            {
+                "Recursive": "true",
+                "SearchTerm": stem,
+                "Fields": "MediaSources,Path",
+                "Limit": "5",
+            },
+        )
+        if not data:
+            return None
+        for item in data.get("Items", []) or []:
+            info = self._extract_from_item(item, stem)
+            if info:
+                return info
+        return None
+
+    def _find_in_series_episodes(
+        self, series_id: str, want_stem: str
+    ) -> Optional[Dict[str, Any]]:
+        """
+        下钻某 Emby 剧集（Series）的所有集，按文件名 stem 精确匹配某一集的媒体流信息。
+
+        剧集路径里的 tmdb-xxxx 是剧集级 ID，命中的 Series 条目本身无 MediaSources，
+        真正带流信息的是每个 Episode，需用 /Shows/{id}/Episodes 下钻后匹配。
+
+        :param series_id: Emby Series 条目 Id
+        :param want_stem: 目标无扩展名文件名
+        :return: 归一化媒体信息，未匹配返回 None
+        """
+        data = self._get(
+            f"/Shows/{series_id}/Episodes",
+            {"Fields": "MediaSources,Path", "Limit": "2000"},
+        )
+        if not data:
+            return None
+        for ep in data.get("Items", []) or []:
+            info = self._extract_from_item(ep, want_stem)
+            if info:
+                return info
+        return None
+
+    @staticmethod
+    def _extract_tmdb_id(path: str) -> Optional[str]:
+        """
+        从 STRM 路径中提取 {tmdb-xxxxx} 里的 TMDB ID。
+
+        :param path: STRM 文件路径
+        :return: TMDB ID 字符串，未找到返回 None
+        """
+        if not path:
+            return None
+        m = re.search(r"tmdb-(\d+)", path, re.IGNORECASE)
+        return m.group(1) if m else None
+
+    @staticmethod
+    def _basename_stem(path: str) -> str:
+        """
+        取路径的无扩展名文件名。
+
+        兼容 STRM 直链场景：Emby 中 STRM 条目的 MediaSource.Path 常是
+        P115StrmHelper 等插件的 302 直链（形如
+        http://host/api/.../redirect_url?pickcode=xxx&file_name=真实文件名.mkv），
+        此时 basename 会取到 query 串，需优先从 file_name 参数还原真实文件名。
+
+        注意不能用 parse_qs：它按表单编码把 "+" 解成空格，会破坏
+        "Disney+" 这类含加号的文件名。这里手动切 query 并只做百分号解码。
+        """
+        if not path:
+            return ""
+        # 直链场景：优先取 query 中的 file_name 参数
+        if path.startswith(("http://", "https://")):
+            try:
+                query = urlparse(path).query
+                for kv in query.split("&"):
+                    for key in ("file_name=", "filename="):
+                        if kv.startswith(key):
+                            fname = unquote(kv[len(key):]).strip()
+                            if fname:
+                                return os.path.splitext(os.path.basename(fname))[0]
+            except Exception:
+                pass
+        return os.path.splitext(os.path.basename(path))[0]
+
+    def _extract_from_item(
+        self, item: Dict[str, Any], want_stem: str
+    ) -> Optional[Dict[str, Any]]:
+        """
+        从 Emby 条目中匹配文件名并抽取归一化媒体流信息。
+
+        :param item: Emby 条目
+        :param want_stem: 目标无扩展名文件名
+        :return: 归一化媒体信息，不匹配返回 None
+        """
+        sources = item.get("MediaSources") or []
+        for src in sources:
+            src_stem = self._basename_stem(src.get("Path") or src.get("Name") or "")
+            if src_stem and src_stem != want_stem:
+                continue
+            info = self._normalize_source(src)
+            if info:
+                return info
+        return None
+
+    def _normalize_source(self, src: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        将 Emby MediaSource 归一化为 helper 需要的 payload 结构。
+
+        :param src: Emby MediaSource
+        :return: 归一化后的媒体信息
+        """
+        streams_in = src.get("MediaStreams") or []
+        if not streams_in:
+            return None
+        # Emby 时长单位 100 纳秒(ticks)，转毫秒
+        ticks = src.get("RunTimeTicks")
+        duration_ms = int(ticks / 10000) if ticks else None
+        info: Dict[str, Any] = {
+            "container": (src.get("Container") or "").split(",")[0] or None,
+            "size": src.get("Size"),
+            "bitrate": int(src["Bitrate"] / 1000) if src.get("Bitrate") else None,
+            "duration": duration_ms,
+            "streams": [],
+            "source": "emby",
+        }
+        # Emby MediaStream.Type: Video/Audio/Subtitle -> Plex stream_type 1/2/3
+        type_map = {"Video": 1, "Audio": 2, "Subtitle": 3}
+        video_seen = False
+        audio_seen = False
+        for s in streams_in:
+            stype = type_map.get(s.get("Type"))
+            if not stype:
+                continue
+            stream = {
+                "stream_type": stype,
+                "codec": (s.get("Codec") or "").lower() or None,
+                "index": s.get("Index"),
+                "language": s.get("Language"),
+            }
+            if stype == 1:
+                stream.update(
+                    {
+                        "width": s.get("Width"),
+                        "height": s.get("Height"),
+                        "bitrate": int(s["BitRate"] / 1000) if s.get("BitRate") else None,
+                        "frame_rate": s.get("RealFrameRate") or s.get("AverageFrameRate"),
+                        "bit_depth": s.get("BitDepth"),
+                    }
+                )
+                if not video_seen:
+                    info["width"] = s.get("Width")
+                    info["height"] = s.get("Height")
+                    info["video_codec"] = (s.get("Codec") or "").lower() or None
+                    info["frame_rate"] = s.get("RealFrameRate") or s.get("AverageFrameRate")
+                    video_seen = True
+            elif stype == 2:
+                stream.update(
+                    {
+                        "bitrate": int(s["BitRate"] / 1000) if s.get("BitRate") else None,
+                        "channels": s.get("Channels"),
+                        "sampling_rate": s.get("SampleRate"),
+                    }
+                )
+                if not audio_seen:
+                    info["audio_codec"] = (s.get("Codec") or "").lower() or None
+                    info["audio_channels"] = s.get("Channels")
+                    audio_seen = True
+            info["streams"].append(stream)
+        return info if info["streams"] else None

--- a/plugins.v3/plextoolbox/ffprobe_source.py
+++ b/plugins.v3/plextoolbox/ffprobe_source.py
@@ -1,0 +1,381 @@
+"""ffprobe 数据源：读取 STRM 内容并探测其中的远程媒体直链。"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import posixpath
+import re
+import subprocess
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+try:
+    from app.sdk.logging import logger
+except Exception:  # pragma: no cover - standalone helper/unit-test fallback
+    logger = logging.getLogger(__name__)
+
+
+PathMapping = Tuple[str, str]
+
+
+def _normalise_path(path: str) -> str:
+    """以 POSIX 规则规范化 Plex/容器路径，保留根路径。"""
+    value = (path or "").strip()
+    if not value:
+        return ""
+    normalised = posixpath.normpath(value)
+    return normalised if normalised == "/" else normalised.rstrip("/")
+
+
+def parse_path_map(raw: str) -> List[PathMapping]:
+    """
+    解析 Plex 路径到 MoviePilot 路径的映射。
+
+    支持每行一条 ``Plex路径=/容器路径`` 或 ``Plex路径 => /容器路径``，
+    也兼容用分号分隔的多条规则。较长的源前缀会在应用时优先匹配。
+    """
+    mappings: List[PathMapping] = []
+    for line in (raw or "").replace(";", "\n").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if "=>" in line:
+            source, target = line.split("=>", 1)
+        elif "=" in line:
+            source, target = line.split("=", 1)
+        else:
+            logger.warning("PlexToolbox 路径映射格式错误，已忽略: %s", line)
+            continue
+        source = _normalise_path(source)
+        target = _normalise_path(target)
+        if not source or not target or not source.startswith("/") or not target.startswith("/"):
+            logger.warning("PlexToolbox 路径映射需使用绝对路径，已忽略: %s", line)
+            continue
+        item = (source, target)
+        if item not in mappings:
+            mappings.append(item)
+    return sorted(mappings, key=lambda item: len(item[0]), reverse=True)
+
+
+def map_path(path: str, mappings: Iterable[PathMapping]) -> str:
+    """将 Plex 文件路径按最长前缀映射为 MoviePilot 可访问的路径。"""
+    value = (path or "").strip()
+    if not value:
+        return ""
+    normalised = _normalise_path(value)
+    for source, target in mappings:
+        if normalised == source or normalised.startswith(source + "/"):
+            suffix = normalised[len(source):]
+            return target + suffix
+    return normalised
+
+
+def read_strm_url(strm_path: str) -> str:
+    """
+    读取 STRM 文件中的第一个有效 HTTP(S) 地址。
+
+    :param strm_path: 对 MoviePilot 进程可读的 STRM 路径
+    :return: STRM 内的远程地址，无法读取时返回空串
+    """
+    if not strm_path:
+        return ""
+    if strm_path.startswith(("http://", "https://")):
+        return strm_path
+    try:
+        if not os.path.isfile(strm_path):
+            return ""
+        with open(strm_path, "r", encoding="utf-8", errors="replace") as stream_file:
+            for line in stream_file:
+                candidate = line.strip().lstrip("\ufeff")
+                if not candidate or candidate.startswith("#"):
+                    continue
+                return candidate if candidate.startswith(("http://", "https://")) else ""
+    except OSError as exc:
+        logger.debug("读取 STRM 失败 %s: %s", strm_path, exc)
+    return ""
+
+
+def _number(value: Any) -> Optional[float]:
+    """将 ffprobe 的数字或 N/A 安全转换为有限浮点数。"""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _integer(value: Any) -> Optional[int]:
+    """将 ffprobe 数字安全转换为整数。"""
+    number = _number(value)
+    return int(number) if number is not None else None
+
+
+def _kbps(value: Any) -> Optional[int]:
+    """将 ffprobe 的 bit/s 转成 Plex 使用的 kbit/s。"""
+    number = _integer(value)
+    return int(number / 1000) if number is not None else None
+
+
+def _parse_fps(value: Any) -> Optional[float]:
+    """解析 ``24000/1001`` 等帧率表示。"""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text in {"N/A", "0/0"}:
+        return None
+    try:
+        if "/" in text:
+            numerator, denominator = text.split("/", 1)
+            denominator_number = float(denominator)
+            if denominator_number == 0:
+                return None
+            rate = float(numerator) / denominator_number
+        else:
+            rate = float(text)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+    return round(rate, 3) if math.isfinite(rate) and rate > 0 else None
+
+
+def _tag_value(tags: Any, name: str) -> Optional[str]:
+    """大小写不敏感地读取 ffprobe stream tag。"""
+    if not isinstance(tags, dict):
+        return None
+    wanted = name.lower()
+    for key, value in tags.items():
+        if str(key).lower() == wanted and value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _normalise_codec(codec_type: str, codec: Any) -> Optional[str]:
+    """将少数 ffprobe 专用字幕 codec 名称归一化为 Plex 常用名称。"""
+    value = str(codec or "").strip().lower()
+    if not value:
+        return None
+    if codec_type == "subtitle":
+        return {
+            "subrip": "srt",
+            "hdmv_pgs_subtitle": "pgs",
+            "dvd_subtitle": "vobsub",
+        }.get(value, value)
+    return value
+
+
+def _normalise_container(format_name: Any) -> Optional[str]:
+    """取 ffprobe format_name 的首个候选并转成常见容器名。"""
+    value = str(format_name or "").split(",", 1)[0].strip().lower()
+    if not value:
+        return None
+    return {
+        "matroska": "mkv",
+        "mov": "mp4",
+        "mpegts": "ts",
+        "hls": "m3u8",
+    }.get(value, value)
+
+
+def _bit_depth(stream: Dict[str, Any]) -> Optional[int]:
+    """从 bits_per_raw_sample 或 pix_fmt 推断视频位深。"""
+    explicit = _integer(stream.get("bits_per_raw_sample"))
+    if explicit:
+        return explicit
+    pixel_format = str(stream.get("pix_fmt") or "").lower()
+    match = re.search(r"(?:p|yuv|rgb)?(16|12|10)(?:le|be)?", pixel_format)
+    if match:
+        return int(match.group(1))
+    return 8 if pixel_format else None
+
+
+def _normalize_ffprobe(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    将 ffprobe JSON 归一化为 helper 接受的媒体信息载荷。
+
+    :param data: ``ffprobe -print_format json -show_format -show_streams`` 输出
+    :return: 归一化媒体信息；没有视频/音频/字幕流时返回 None
+    """
+    if not isinstance(data, dict):
+        return None
+    fmt = data.get("format") or {}
+    streams_in = data.get("streams") or []
+    if not isinstance(fmt, dict) or not isinstance(streams_in, list):
+        return None
+
+    duration_seconds = _number(fmt.get("duration"))
+    if duration_seconds is None:
+        stream_durations = [_number(item.get("duration")) for item in streams_in if isinstance(item, dict)]
+        stream_durations = [item for item in stream_durations if item is not None]
+        if stream_durations:
+            duration_seconds = max(stream_durations)
+
+    info: Dict[str, Any] = {
+        "container": _normalise_container(fmt.get("format_name")),
+        "size": _integer(fmt.get("size")),
+        "bitrate": _kbps(fmt.get("bit_rate")),
+        "duration": int(duration_seconds * 1000) if duration_seconds is not None else None,
+        "streams": [],
+        "source": "ffprobe",
+    }
+    type_map = {"video": 1, "audio": 2, "subtitle": 3}
+    video_seen = False
+    audio_seen = False
+    for source_stream in streams_in:
+        if not isinstance(source_stream, dict):
+            continue
+        codec_type = str(source_stream.get("codec_type") or "").lower()
+        stream_type = type_map.get(codec_type)
+        if not stream_type:
+            continue
+        codec = _normalise_codec(codec_type, source_stream.get("codec_name"))
+        stream: Dict[str, Any] = {
+            "stream_type": stream_type,
+            "codec": codec,
+            "index": _integer(source_stream.get("index")),
+            "language": _tag_value(source_stream.get("tags"), "language"),
+        }
+        if stream_type == 1:
+            frame_rate = _parse_fps(
+                source_stream.get("avg_frame_rate") or source_stream.get("r_frame_rate")
+            )
+            stream.update(
+                {
+                    "width": _integer(source_stream.get("width")),
+                    "height": _integer(source_stream.get("height")),
+                    "bitrate": _kbps(source_stream.get("bit_rate")),
+                    "frame_rate": frame_rate,
+                    "bit_depth": _bit_depth(source_stream),
+                }
+            )
+            if not video_seen:
+                info.update(
+                    {
+                        "width": _integer(source_stream.get("width")),
+                        "height": _integer(source_stream.get("height")),
+                        "video_codec": codec,
+                        "frame_rate": frame_rate,
+                        "display_aspect_ratio": _number(
+                            source_stream.get("display_aspect_ratio")
+                        ),
+                    }
+                )
+                video_seen = True
+        elif stream_type == 2:
+            stream.update(
+                {
+                    "bitrate": _kbps(source_stream.get("bit_rate")),
+                    "channels": _integer(source_stream.get("channels")),
+                    "sampling_rate": _integer(source_stream.get("sample_rate")),
+                }
+            )
+            if not audio_seen:
+                info.update(
+                    {
+                        "audio_codec": codec,
+                        "audio_channels": _integer(source_stream.get("channels")),
+                    }
+                )
+                audio_seen = True
+        info["streams"].append(stream)
+    return info if info["streams"] else None
+
+
+def ffprobe_url(
+    url: str, timeout: float = 40.0, executable: str = "ffprobe"
+) -> Optional[Dict[str, Any]]:
+    """
+    对远程媒体 URL 执行 ffprobe。
+
+    ffprobe 自带 HTTP 302 跟随能力，因此直接探测 STRM 中的 P115 地址即可，
+    不额外做 HEAD 请求，避免部分 302 服务不支持 HEAD 或导致一次额外延迟。
+    """
+    if not url or not url.startswith(("http://", "https://")):
+        return None
+    try:
+        timeout_value = max(1.0, float(timeout))
+    except (TypeError, ValueError):
+        timeout_value = 40.0
+    command = [
+        executable,
+        "-nostdin",
+        "-v",
+        "error",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        "-analyzeduration",
+        "10000000",
+        "-probesize",
+        "10000000",
+        url,
+    ]
+    try:
+        process = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout_value,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.debug("ffprobe 执行超时")
+        return None
+    except OSError as exc:
+        logger.debug("ffprobe 进程错误: %s", exc)
+        return None
+    if process.returncode != 0:
+        # stderr 可能回显包含授权参数的输入 URL，不写入日志。
+        logger.debug("ffprobe 返回码 %s", process.returncode)
+        return None
+    try:
+        result = json.loads(process.stdout or "{}")
+    except (TypeError, ValueError) as exc:
+        logger.debug("ffprobe JSON 解析失败: %s", exc)
+        return None
+    return _normalize_ffprobe(result)
+
+
+class FfprobeSource:
+    """将 Plex 返回的文件路径转换为 MP 路径并提供 ffprobe 媒体信息。"""
+
+    def __init__(self, path_map: str = "", timeout: float = 40.0) -> None:
+        self._mappings = parse_path_map(path_map)
+        try:
+            self._timeout = max(1.0, float(timeout))
+        except (TypeError, ValueError):
+            self._timeout = 40.0
+
+    def mapped_path(self, plex_path: str) -> str:
+        """返回当前 MoviePilot 容器实际可访问的路径。"""
+        return map_path(plex_path, self._mappings)
+
+    def find_streams_by_name(self, file_path: str) -> Optional[Dict[str, Any]]:
+        """
+        读取 Plex STRM 的首行 URL并探测媒体流。
+
+        :param file_path: Plex API 返回的 STRM 路径，或直接的 HTTP(S) URL
+        :return: helper 媒体信息载荷，失败返回 None
+        """
+        if not file_path:
+            return None
+        if file_path.startswith(("http://", "https://")):
+            mapped = file_path
+            url = file_path
+        else:
+            mapped = self.mapped_path(file_path)
+            url = read_strm_url(mapped)
+        # 映射配置写错时仍尝试原始路径，兼容 Plex 与 MP 共享同一目录的情况。
+        if not url and mapped != file_path:
+            url = read_strm_url(file_path)
+        if not url:
+            logger.debug("ffprobe 找不到 STRM URL: %s", mapped)
+            return None
+        info = ffprobe_url(url, timeout=self._timeout)
+        if info:
+            return info
+        logger.debug("ffprobe 未解析到媒体流: %s", mapped)
+        return None

--- a/plugins.v3/plextoolbox/ffprobe_source.py
+++ b/plugins.v3/plextoolbox/ffprobe_source.py
@@ -300,7 +300,6 @@ def ffprobe_url(
         timeout_value = 40.0
     command = [
         executable,
-        "-nostdin",
         "-v",
         "error",
         "-print_format",

--- a/plugins.v3/plextoolbox/helper/Dockerfile
+++ b/plugins.v3/plextoolbox/helper/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-alpine
+
+# Plex MediaInfo Helper —— 在 Plex 所在机器本地安全写库的小服务
+# 仅依赖 Python 标准库，无需 pip 安装任何包
+
+WORKDIR /app
+COPY plex_mediainfo_helper.py /app/plex_mediainfo_helper.py
+
+# 默认端口，可用环境变量 PTH_PORT 覆盖
+EXPOSE 9001
+
+# 健康检查
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python3 -c "import urllib.request,os; urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('PTH_PORT','9001')+'/health',timeout=4)" || exit 1
+
+ENTRYPOINT ["python3", "/app/plex_mediainfo_helper.py"]

--- a/plugins.v3/plextoolbox/helper/README.md
+++ b/plugins.v3/plextoolbox/helper/README.md
@@ -1,0 +1,221 @@
+# Plex MediaInfo Helper 部署说明
+
+在 **Plex 所在机器（192.168.0.122）** 上运行的本地写库小服务。PlexToolbox 插件负责计算媒体流信息，通过 HTTP 发送到本服务，由本服务在 **数据库文件本地** 安全写入，避免跨网络写 SQLite 损库。
+
+## 前置：找到 Plex 数据库路径
+
+数据库文件名为 `com.plexapp.plugins.library.db`，通常在 Plex 配置目录下：
+
+```
+.../Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db
+```
+
+Docker 版 Plex 一般把配置目录挂在宿主机某处（如 `/path/to/plex/config`）。找到后，数据库就在该目录下的 `Library/Application Support/.../Databases/`。
+
+## 方式 A：直接跑 Python + systemd（推荐，实际部署方式）
+
+helper 纯 Python 标准库、零依赖，直接在能访问数据库文件的那层（LXC 或宿主）用 systemd 常驻即可，比 Docker 少一层文件系统开销。
+
+下文用到两个占位符，请全程替换成你自己的值：
+
+- `MySecretToken123`：helper 访问密码，自己随便设一串，稍后同样填进插件配置的「helper Token」
+- `YourPlexTokenHere`：你的 Plex Token（用于繁忙检测，可留空跳过）
+
+### 逐步部署（一条一条敲）
+
+**第 1 步：SSH 登录 Plex 所在机器**
+
+```bash
+ssh root@192.168.0.122
+```
+
+**第 2 步：创建部署目录**
+
+```bash
+mkdir -p /opt/plex/helper
+```
+
+**第 3 步：把脚本传上去**（这条在 MoviePilot 那台机器上敲，不是在 Plex 机器上）
+
+```bash
+scp plex_mediainfo_helper.py root@192.168.0.122:/opt/plex/helper/
+```
+
+**第 4 步：创建 systemd 服务文件**（回到 Plex 机器上，用 nano 编辑器）
+
+```bash
+nano /etc/systemd/system/plex-mediainfo-helper.service
+```
+
+打开编辑器后，把下面内容整段粘贴进去（改好两个 token 和数据库路径），然后按 `Ctrl+O` 回车保存、`Ctrl+X` 退出：
+
+```ini
+[Unit]
+Description=Plex MediaInfo Helper
+After=network.target
+
+[Service]
+Type=simple
+Environment=PTH_HOST=0.0.0.0
+Environment=PTH_PORT=9001
+Environment=PTH_TOKEN=MySecretToken123
+Environment="PTH_DB_PATH=/opt/plex/config/Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db"
+Environment=PTH_PLEX_URL=http://127.0.0.1:32400
+Environment=PTH_PLEX_TOKEN=YourPlexTokenHere
+Environment=PTH_BACKUP_ON_WRITE=0
+ExecStart=/usr/bin/python3 /opt/plex/helper/plex_mediainfo_helper.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> ⚠️ `PTH_DB_PATH` 那行因为路径带空格，整个 `KEY=value` 要用双引号包住（如上）。数据库路径改成你的实际路径。
+
+**第 5 步：启动并设开机自启**（逐条敲）
+
+```bash
+systemctl daemon-reload
+```
+
+```bash
+systemctl enable --now plex-mediainfo-helper
+```
+
+**第 6 步：验证**（逐条敲，都在 Plex 机器上）
+
+```bash
+systemctl status plex-mediainfo-helper --no-pager
+```
+
+```bash
+curl http://127.0.0.1:9001/health
+```
+
+```bash
+curl -H "X-PTH-Token: MySecretToken123" http://127.0.0.1:9001/dbinfo
+```
+
+看到 `status` 显示 `active (running)`、`/health` 返回 `{"ok": true...}`、`/dbinfo` 返回 `"success": true` 即部署完成。
+
+### 日常更新 helper（改了脚本后）
+
+只需两条。第一条在 MoviePilot 机器上敲：
+
+```bash
+scp plex_mediainfo_helper.py root@192.168.0.122:/opt/plex/helper/
+```
+
+第二条在 Plex 机器上敲：
+
+```bash
+systemctl restart plex-mediainfo-helper
+```
+
+### 常用运维命令
+
+```bash
+systemctl restart plex-mediainfo-helper     # 重启
+systemctl stop plex-mediainfo-helper        # 停止
+journalctl -u plex-mediainfo-helper -f      # 看实时日志
+journalctl -u plex-mediainfo-helper -n 100  # 看最近 100 行日志
+```
+
+## 方式 B：Docker 运行（备选）
+
+在 Plex 所在机器上，把 Plex 的 **配置目录** 挂进 helper 容器（只需能读写到数据库文件即可）。
+
+### 1. 构建镜像
+
+把 `helper/` 目录（含 `plex_mediainfo_helper.py` 和 `Dockerfile`）拷到目标机器，然后：
+
+```bash
+cd helper
+docker build -t plex-mediainfo-helper:latest .
+```
+
+### 2. 运行容器
+
+```bash
+docker run -d --name plex-mediainfo-helper \
+  --restart unless-stopped \
+  -p 9001:9001 \
+  -v "/path/to/plex/config/Library/Application Support/Plex Media Server/Plug-in Support/Databases":"/db" \
+  -e PTH_DB_PATH="/db/com.plexapp.plugins.library.db" \
+  -e PTH_TOKEN="换成一个自定义密码" \
+  -e PTH_PLEX_URL="http://192.168.0.122:32400" \
+  -e PTH_PLEX_TOKEN="你的PlexToken" \
+  plex-mediainfo-helper:latest
+```
+
+> 把 `/path/to/plex/config` 换成 Plex 实际的配置目录。
+> `PTH_TOKEN` 自定义一个密码，稍后填进插件。
+> `PTH_PLEX_TOKEN` 用于「Plex 繁忙时拒绝写入」的检测，可留空则跳过检测。
+
+### 方式 B2：docker compose
+
+`helper/` 目录内已提供 `docker-compose.yml`。改好里面的挂载路径与 token 后：
+
+```bash
+cd helper
+docker compose up -d
+```
+
+需要修改的地方：`volumes` 左侧换成 Plex 实际的 `Databases` 目录，`PTH_TOKEN` 自定义密码，`PTH_PLEX_TOKEN` 填你的 Plex token（留空则跳过繁忙检测）。
+
+## 无 Emby 时使用 ffprobe
+
+PlexToolbox V3 可以不依赖 Emby：MoviePilot 会读取 Plex 条目对应的 `.strm` 首行，
+直接用 ffprobe 探测其中的 P115 302 地址，再把媒体流信息发送给本 helper 写入 Plex。
+该流程只读取 STRM，不会改写 STRM 内容；helper 仍必须部署在 Plex 数据库所在机器。
+
+在 PlexToolbox 的「媒体信息补全」中：
+
+1. 开启「启用 ffprobe」，Emby 可留空或关闭。
+2. 将「Plex 路径 → MoviePilot 容器路径映射」设为实际映射，例如
+   `/Volumes/data=/media`。
+3. 确认 MP 容器能访问映射后的 `.strm` 文件，并用「检查 helper」确认写库服务可达。
+
+路径左侧是 Plex API 返回的路径，右侧是 MoviePilot 容器内的路径；多条映射每行一条。
+
+### 3. 验证
+
+```bash
+# 健康检查（无需 token）
+curl http://192.168.0.122:9001/health
+
+# 确认找到数据库（需 token）
+curl -H "X-PTH-Token: 换成一个自定义密码" http://192.168.0.122:9001/dbinfo
+```
+
+## 环境变量
+
+| 变量 | 默认 | 说明 |
+|------|------|------|
+| `PTH_HOST` | `0.0.0.0` | 监听地址 |
+| `PTH_PORT` | `9001` | 监听端口 |
+| `PTH_TOKEN` | 空 | 访问令牌，插件请求需带 `X-PTH-Token`；留空不校验 |
+| `PTH_DB_PATH` | 空 | 数据库路径；留空则自动探测 |
+| `PTH_BACKUP_KEEP` | `10` | 数据库备份保留份数 |
+| `PTH_PLEX_URL` | `http://127.0.0.1:32400` | 本地 Plex 地址（繁忙检测用） |
+| `PTH_PLEX_TOKEN` | 空 | Plex token（繁忙检测用）；留空跳过检测 |
+| `PTH_REFUSE_WHEN_PLAYING` | `1` | 有播放会话时拒绝写入 |
+| `PTH_BACKUP_ON_WRITE` | `0` | 每次写入前是否备份数据库；大库全量备份耗时高，默认关闭，需要兜底时置 `1` |
+
+## 安全说明
+
+- 写入前可选备份数据库到同目录 `pth_backups/`（`PTH_BACKUP_ON_WRITE=1` 开启，保留最近 N 份；默认关闭以提升写入速度）。
+- 写入前检测 Plex 是否在播放/扫描，繁忙则拒绝（可用 `force` 覆盖）。
+- 只写 Plex 数据库中 **实际存在的列**，不改表结构。
+- 写 Plex 库属于非官方操作，Plex 大版本升级可能改表结构；升级后先用 `/dbinfo` 验证。
+
+## 接口
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/health` | 健康检查（无需 token） |
+| GET | `/dbinfo` | 返回数据库路径与候选 |
+| GET | `/busy` | 返回 Plex 是否繁忙 |
+| POST | `/write` | 写入单个 part 的媒体信息 |
+| POST | `/write_batch` | 批量写入 |

--- a/plugins.v3/plextoolbox/helper/docker-compose.yml
+++ b/plugins.v3/plextoolbox/helper/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  plex-mediainfo-helper:
+    build: .
+    image: plex-mediainfo-helper:latest
+    container_name: plex-mediainfo-helper
+    restart: unless-stopped
+    ports:
+      - "9001:9001"
+    volumes:
+      # 左侧改成 122 上 Plex 实际的 Databases 目录（含 com.plexapp.plugins.library.db）
+      - "/path/to/plex/config/Library/Application Support/Plex Media Server/Plug-in Support/Databases:/db"
+    environment:
+      PTH_DB_PATH: "/db/com.plexapp.plugins.library.db"
+      # 自定义一个访问密码，稍后填进插件
+      PTH_TOKEN: "换成一个自定义密码"
+      # 繁忙检测用；PTH_PLEX_TOKEN 留空则跳过检测
+      PTH_PLEX_URL: "http://192.168.0.122:32400"
+      PTH_PLEX_TOKEN: "你的PlexToken"
+      # 可选：备份保留份数、有播放时是否拒写
+      PTH_BACKUP_KEEP: "10"
+      PTH_REFUSE_WHEN_PLAYING: "1"

--- a/plugins.v3/plextoolbox/helper/plex_mediainfo_helper.py
+++ b/plugins.v3/plextoolbox/helper/plex_mediainfo_helper.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""
+Plex MediaInfo Helper —— 运行在 Plex 所在机器上的本地写库小服务。
+
+设计目标：
+- 只在 Plex 数据库文件本地做写入，避免跨网络写 SQLite 造成的锁/损库风险。
+- 由 MoviePilot 侧的 PlexToolbox 插件计算好媒体流信息后，通过 HTTP 发送到本服务写入。
+- 写入前自动备份数据库、检测 Plex 是否繁忙、运行时自省表结构，兼容不同 Plex 版本。
+
+安全约束：
+- 仅监听内网地址，并用简单 token 校验。
+- 每次写入前对数据库做带时间戳的备份，仅保留最近 N 份。
+- 使用 WAL + busy_timeout，并对写操作串行化。
+- 通过 PRAGMA table_info 自省列名，只写实际存在的列，绝不 ALTER TABLE。
+
+仅依赖 Python 标准库。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import threading
+from datetime import datetime
+from glob import glob
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, List, Optional, Tuple
+
+LISTEN_HOST = os.environ.get("PTH_HOST", "0.0.0.0")
+LISTEN_PORT = int(os.environ.get("PTH_PORT", "9001"))
+ACCESS_TOKEN = os.environ.get("PTH_TOKEN", "")
+DB_PATH = os.environ.get("PTH_DB_PATH", "").strip()
+BACKUP_KEEP = int(os.environ.get("PTH_BACKUP_KEEP", "10"))
+PLEX_LOCAL_URL = os.environ.get("PTH_PLEX_URL", "http://127.0.0.1:32400").rstrip("/")
+PLEX_TOKEN = os.environ.get("PTH_PLEX_TOKEN", "").strip()
+REFUSE_WHEN_PLAYING = os.environ.get("PTH_REFUSE_WHEN_PLAYING", "1") == "1"
+# 每次写入前是否备份数据库。全量备份大库耗时高（写慢的主因之一），默认关闭；
+# 需要兜底时置 PTH_BACKUP_ON_WRITE=1。
+BACKUP_ON_WRITE = os.environ.get("PTH_BACKUP_ON_WRITE", "0") == "1"
+
+DB_CANDIDATES = [
+    "/config/Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db",
+    "/data/Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db",
+    "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db",
+    "/plex/Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db",
+]
+
+_WRITE_LOCK = threading.Lock()
+
+
+def _now_str() -> str:
+    """返回用于备份文件名的时间戳字符串。"""
+    return datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def discover_db_path() -> str:
+    """
+    探测 Plex 数据库文件路径。优先使用显式配置，否则遍历候选与浅层通配搜索。
+
+    :return: 找到的数据库路径，未找到返回空串
+    """
+    if DB_PATH and os.path.isfile(DB_PATH):
+        return DB_PATH
+    for cand in DB_CANDIDATES:
+        if os.path.isfile(cand):
+            return cand
+    for pat in (
+        "/config/**/com.plexapp.plugins.library.db",
+        "/data/**/com.plexapp.plugins.library.db",
+        "/plex/**/com.plexapp.plugins.library.db",
+    ):
+        hits = glob(pat, recursive=True)
+        if hits:
+            return hits[0]
+    return ""
+
+
+def list_db_candidates() -> List[str]:
+    """
+    列出所有存在的数据库候选路径，供人工确认使用。
+
+    :return: 存在的候选路径列表
+    """
+    found: List[str] = []
+    for cand in DB_CANDIDATES:
+        if os.path.isfile(cand) and cand not in found:
+            found.append(cand)
+    for pat in (
+        "/config/**/com.plexapp.plugins.library.db",
+        "/data/**/com.plexapp.plugins.library.db",
+        "/plex/**/com.plexapp.plugins.library.db",
+    ):
+        for h in glob(pat, recursive=True):
+            if h not in found:
+                found.append(h)
+    return found
+
+
+def backup_db(db_path: str) -> str:
+    """
+    备份数据库文件（含 -wal/-shm），并清理超出保留份数的旧备份。
+
+    :param db_path: 数据库文件路径
+    :return: 备份文件路径
+    """
+    backup_dir = os.path.join(os.path.dirname(db_path), "pth_backups")
+    os.makedirs(backup_dir, exist_ok=True)
+    base = os.path.basename(db_path)
+    dst = os.path.join(backup_dir, f"{base}.{_now_str()}.bak")
+    shutil.copy2(db_path, dst)
+    for suffix in ("-wal", "-shm"):
+        side = db_path + suffix
+        if os.path.isfile(side):
+            shutil.copy2(side, dst + suffix)
+    backups = sorted(glob(os.path.join(backup_dir, f"{base}.*.bak")))
+    excess = len(backups) - BACKUP_KEEP
+    for old in backups[: max(0, excess)]:
+        try:
+            os.remove(old)
+            for suffix in ("-wal", "-shm"):
+                if os.path.isfile(old + suffix):
+                    os.remove(old + suffix)
+        except OSError:
+            pass
+    return dst
+
+
+def plex_is_busy() -> Tuple[bool, str]:
+    """
+    检测 Plex 是否繁忙（有播放会话或正在扫描）。无法查询时视为不繁忙。
+
+    :return: (是否繁忙, 说明)
+    """
+    if not PLEX_TOKEN:
+        return False, "未配置 Plex token，跳过繁忙检测"
+    import urllib.request
+
+    def _get(path: str) -> Optional[str]:
+        """请求本地 Plex API 并返回响应文本，失败返回 None。"""
+        sep = "&" if "?" in path else "?"
+        url = f"{PLEX_LOCAL_URL}{path}{sep}X-Plex-Token={PLEX_TOKEN}"
+        try:
+            req = urllib.request.Request(url, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=6) as r:
+                return r.read().decode("utf-8", errors="replace")
+        except Exception:
+            return None
+
+    if REFUSE_WHEN_PLAYING:
+        body = _get("/status/sessions")
+        if body:
+            try:
+                size = json.loads(body).get("MediaContainer", {}).get("size", 0)
+                if int(size or 0) > 0:
+                    return True, f"存在 {size} 个播放会话"
+            except (ValueError, TypeError):
+                pass
+    body = _get("/library/sections")
+    if body:
+        try:
+            dirs = json.loads(body).get("MediaContainer", {}).get("Directory", [])
+            for d in dirs:
+                if str(d.get("refreshing")) in ("1", "true", "True"):
+                    return True, "有媒体库正在刷新/扫描"
+        except (ValueError, TypeError):
+            pass
+    return False, "空闲"
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> List[str]:
+    """
+    通过 PRAGMA 自省表的列名。
+
+    :param conn: 数据库连接
+    :param table: 表名
+    :return: 列名列表
+    """
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    return [row[1] for row in cur.fetchall()]
+
+
+def _filter_columns(data: Dict[str, Any], allowed: List[str]) -> Dict[str, Any]:
+    """
+    仅保留目标表中真实存在且非空的列。
+
+    :param data: 待写入的键值
+    :param allowed: 表实际存在的列名
+    :return: 过滤后的键值
+    """
+    return {k: v for k, v in data.items() if k in allowed and v is not None}
+
+
+def _upsert(
+    conn: sqlite3.Connection,
+    table: str,
+    key_cols: List[str],
+    row: Dict[str, Any],
+) -> str:
+    """
+    按主键列做存在则更新、不存在则插入。
+
+    :param conn: 数据库连接
+    :param table: 表名
+    :param key_cols: 定位记录的键列
+    :param row: 已过滤为真实列的键值
+    :return: 'update'、'insert' 或 'skip'
+    """
+    if not row:
+        return "skip"
+    keys = [c for c in key_cols if c in row]
+    where = " AND ".join(f'"{c}"=?' for c in keys)
+    where_vals = [row[c] for c in keys]
+    exists = False
+    if where:
+        cur = conn.execute(f"SELECT 1 FROM {table} WHERE {where} LIMIT 1", where_vals)
+        exists = cur.fetchone() is not None
+    if exists:
+        set_cols = [c for c in row.keys() if c not in key_cols]
+        if not set_cols:
+            return "skip"
+        set_clause = ", ".join(f'"{c}"=?' for c in set_cols)
+        conn.execute(
+            f"UPDATE {table} SET {set_clause} WHERE {where}",
+            [row[c] for c in set_cols] + where_vals,
+        )
+        return "update"
+    cols = list(row.keys())
+    quoted = ", ".join(f'"{c}"' for c in cols)
+    placeholders = ", ".join("?" for _ in cols)
+    conn.execute(
+        f"INSERT INTO {table} ({quoted}) VALUES ({placeholders})",
+        [row[c] for c in cols],
+    )
+    return "insert"
+
+
+def _open_conn(db_path: str) -> sqlite3.Connection:
+    """
+    打开写库连接并设置 WAL/busy_timeout。
+
+    :param db_path: 数据库路径
+    :return: 数据库连接
+    """
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    conn.execute("PRAGMA busy_timeout=30000")
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def _write_one(conn: sqlite3.Connection, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    在已开启事务的连接上写入单条媒体信息（用 SAVEPOINT 隔离失败项）。
+
+    payload 关键字段：part_id（必填，media_parts.id）、media_item_id（可选）、
+    container/duration/size/bitrate/width/height/video_codec/audio_codec、
+    streams（逐条流列表，含 stream_type 1视频/2音频/3字幕）、overwrite_streams。
+
+    :param conn: 已建立的数据库连接（外层负责 BEGIN/COMMIT）
+    :param payload: 媒体信息载荷
+    :return: 写入结果统计
+    """
+    part_id = payload.get("part_id")
+    if not part_id:
+        return {"success": False, "error": "缺少 part_id"}
+    result: Dict[str, Any] = {
+        "success": False,
+        "part_id": part_id,
+        "media_items": "skip",
+        "media_parts": "skip",
+        "streams_deleted": 0,
+        "streams_written": 0,
+    }
+    conn.execute("SAVEPOINT item_write")
+    try:
+        media_item_id = payload.get("media_item_id")
+        if not media_item_id:
+            cur = conn.execute(
+                "SELECT media_item_id FROM media_parts WHERE id=?", (part_id,)
+            )
+            row = cur.fetchone()
+            if row:
+                media_item_id = row[0]
+        if not media_item_id:
+            conn.execute("ROLLBACK TO item_write")
+            result["error"] = f"无法定位 part_id={part_id} 的 media_item_id"
+            return result
+
+        mi_cols = _table_columns(conn, "media_items")
+        mi_row = _filter_columns(
+            {
+                "id": media_item_id,
+                "width": payload.get("width"),
+                "height": payload.get("height"),
+                "duration": payload.get("duration"),
+                "bitrate": payload.get("bitrate"),
+                "container": payload.get("container"),
+                "video_codec": payload.get("video_codec"),
+                "audio_codec": payload.get("audio_codec"),
+                "display_aspect_ratio": payload.get("display_aspect_ratio"),
+                "frames_per_second": payload.get("frame_rate"),
+                "audio_channels": payload.get("audio_channels"),
+                "media_analysis_version": 6,
+            },
+            mi_cols,
+        )
+        if mi_row:
+            result["media_items"] = _upsert(conn, "media_items", ["id"], mi_row)
+
+        mp_cols = _table_columns(conn, "media_parts")
+        mp_row = _filter_columns(
+            {
+                "id": part_id,
+                "duration": payload.get("duration"),
+                "size": payload.get("size"),
+                "container": payload.get("container"),
+            },
+            mp_cols,
+        )
+        if mp_row:
+            result["media_parts"] = _upsert(conn, "media_parts", ["id"], mp_row)
+
+        streams = payload.get("streams") or []
+        if streams:
+            ms_cols = _table_columns(conn, "media_streams")
+            if payload.get("overwrite_streams"):
+                cur = conn.execute(
+                    "DELETE FROM media_streams WHERE media_part_id=?", (part_id,)
+                )
+                result["streams_deleted"] = cur.rowcount or 0
+            written = 0
+            for st in streams:
+                # 兼容不同 Plex 版本的流类型列名（stream_type_id / stream_type）
+                stype = st.get("stream_type")
+                st_row = _filter_columns(
+                    {
+                        "media_item_id": media_item_id,
+                        "media_part_id": part_id,
+                        "stream_type_id": stype,
+                        "stream_type": stype,
+                        "codec": st.get("codec"),
+                        "index": st.get("index"),
+                        "width": st.get("width"),
+                        "height": st.get("height"),
+                        "bitrate": st.get("bitrate"),
+                        "channels": st.get("channels"),
+                        "language": st.get("language"),
+                        "frame_rate": st.get("frame_rate"),
+                        "bit_depth": st.get("bit_depth"),
+                        "sampling_rate": st.get("sampling_rate"),
+                    },
+                    ms_cols,
+                )
+                if st_row:
+                    quoted = ", ".join(f'"{c}"' for c in st_row.keys())
+                    conn.execute(
+                        f"INSERT INTO media_streams ({quoted}) "
+                        f"VALUES ({', '.join('?' for _ in st_row)})",
+                        list(st_row.values()),
+                    )
+                    written += 1
+            result["streams_written"] = written
+
+        conn.execute("RELEASE item_write")
+        result["success"] = True
+        return result
+    except Exception as e:
+        try:
+            conn.execute("ROLLBACK TO item_write")
+        except sqlite3.Error:
+            pass
+        result["error"] = f"写入异常: {e}"
+        return result
+
+
+def write_media_info(db_path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    单条写入入口：建连接、开事务、写入并提交。
+
+    :param db_path: 数据库路径
+    :param payload: 媒体信息载荷
+    :return: 写入结果统计
+    """
+    conn = _open_conn(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        result = _write_one(conn, payload)
+        if result.get("success"):
+            conn.commit()
+        else:
+            conn.rollback()
+        return result
+    except Exception as e:
+        conn.rollback()
+        return {"success": False, "part_id": payload.get("part_id"), "error": f"写入异常: {e}"}
+    finally:
+        conn.close()
+
+
+def write_media_info_batch(
+    db_path: str, items: List[Dict[str, Any]]
+) -> Tuple[int, List[Dict[str, Any]]]:
+    """
+    批量写入：整批共用一个连接一个事务，单条失败用 SAVEPOINT 回滚不影响其余。
+
+    :param db_path: 数据库路径
+    :param items: 媒体信息载荷列表
+    :return: (成功条数, 每条结果列表)
+    """
+    results: List[Dict[str, Any]] = []
+    ok = 0
+    conn = _open_conn(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        for it in items:
+            r = _write_one(conn, it)
+            if r.get("success"):
+                ok += 1
+            results.append(r)
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        # 整批事务级失败：未产生结果的项标记失败
+        while len(results) < len(items):
+            results.append(
+                {
+                    "success": False,
+                    "part_id": items[len(results)].get("part_id"),
+                    "error": f"批量事务异常: {e}",
+                }
+            )
+        ok = sum(1 for r in results if r.get("success"))
+    finally:
+        conn.close()
+    return ok, results
+
+
+class Handler(BaseHTTPRequestHandler):
+    """HTTP 请求处理器：提供健康检查、DB 探测、繁忙检测、写入接口。"""
+
+    server_version = "PlexMediaInfoHelper/1.0"
+
+    def _send(self, code: int, obj: Dict[str, Any]) -> None:
+        """发送 JSON 响应。"""
+        body = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _check_token(self) -> bool:
+        """校验访问 token。未配置 token 时不校验。"""
+        if not ACCESS_TOKEN:
+            return True
+        return self.headers.get("X-PTH-Token", "") == ACCESS_TOKEN
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        """精简访问日志输出。"""
+        print(f"[{_now_str()}] {self.address_string()} {fmt % args}")
+
+    def do_GET(self) -> None:
+        """处理 GET：/health、/dbinfo、/busy。"""
+        if self.path == "/health":
+            self._send(200, {"ok": True, "service": "plex-mediainfo-helper"})
+            return
+        if not self._check_token():
+            self._send(401, {"success": False, "error": "token 校验失败"})
+            return
+        if self.path == "/dbinfo":
+            db = discover_db_path()
+            self._send(
+                200,
+                {
+                    "success": bool(db),
+                    "db_path": db,
+                    "candidates": list_db_candidates(),
+                    "backup_keep": BACKUP_KEEP,
+                },
+            )
+            return
+        if self.path == "/busy":
+            busy, reason = plex_is_busy()
+            self._send(200, {"success": True, "busy": busy, "reason": reason})
+            return
+        self._send(404, {"success": False, "error": "未知路径"})
+
+    def do_POST(self) -> None:
+        """处理 POST：/write（单条）、/write_batch（批量）。"""
+        if not self._check_token():
+            self._send(401, {"success": False, "error": "token 校验失败"})
+            return
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        raw = self.rfile.read(length) if length else b""
+        try:
+            payload = json.loads(raw.decode("utf-8")) if raw else {}
+        except ValueError:
+            self._send(400, {"success": False, "error": "请求体非合法 JSON"})
+            return
+
+        db = discover_db_path()
+        if not db:
+            self._send(
+                500,
+                {"success": False, "error": "未找到 Plex 数据库，请设置 PTH_DB_PATH"},
+            )
+            return
+
+        force = bool(payload.get("force"))
+        if not force:
+            busy, reason = plex_is_busy()
+            if busy:
+                self._send(
+                    409, {"success": False, "error": f"Plex 繁忙：{reason}", "busy": True}
+                )
+                return
+
+        with _WRITE_LOCK:
+            backup = backup_db(db) if BACKUP_ON_WRITE else ""
+            if self.path == "/write":
+                res = write_media_info(db, payload)
+                res["backup"] = backup
+                self._send(200 if res.get("success") else 500, res)
+                return
+            if self.path == "/write_batch":
+                items = payload.get("items") or []
+                ok, results = write_media_info_batch(db, items)
+                self._send(
+                    200,
+                    {
+                        "success": True,
+                        "total": len(items),
+                        "ok": ok,
+                        "backup": backup,
+                        "results": results,
+                    },
+                )
+                return
+        self._send(404, {"success": False, "error": "未知路径"})
+
+
+def main() -> None:
+    """启动 HTTP 服务并打印初始化信息。"""
+    db = discover_db_path()
+    print("=" * 60)
+    print("Plex MediaInfo Helper 启动")
+    print(f"监听: {LISTEN_HOST}:{LISTEN_PORT}")
+    print(f"Token: {'已设置' if ACCESS_TOKEN else '未设置（不校验，仅限内网）'}")
+    if db:
+        print(f"数据库: {db}")
+    else:
+        print("数据库: 未找到！候选路径:")
+        for c in list_db_candidates():
+            print(f"  - {c}")
+        print("请通过环境变量 PTH_DB_PATH 指定数据库路径。")
+    print(f"备份保留: {BACKUP_KEEP} 份")
+    print(f"写前备份: {'开' if BACKUP_ON_WRITE else '关（PTH_BACKUP_ON_WRITE=1 可开启）'}")
+    print(f"繁忙拒写: {'开' if REFUSE_WHEN_PLAYING else '关'}")
+    print("=" * 60)
+    ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins.v3/plextoolbox/helper/selftest.py
+++ b/plugins.v3/plextoolbox/helper/selftest.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""helper 写库逻辑本地自测：用模拟 Plex 表结构验证 upsert/列自省/备份。"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(__file__))
+import plex_mediainfo_helper as h
+
+
+def build_fake_db(path: str) -> None:
+    """构建一个近似 Plex 结构的模拟数据库，含 media_items/parts/streams。"""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE media_items (
+            id INTEGER PRIMARY KEY, width INTEGER, height INTEGER,
+            duration INTEGER, bitrate INTEGER, container TEXT,
+            video_codec TEXT, audio_codec TEXT, display_aspect_ratio REAL,
+            frames_per_second REAL, audio_channels INTEGER
+        );
+        CREATE TABLE media_parts (
+            id INTEGER PRIMARY KEY, media_item_id INTEGER,
+            duration INTEGER, size INTEGER, container TEXT, file TEXT
+        );
+        CREATE TABLE media_streams (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, media_item_id INTEGER,
+            media_part_id INTEGER, stream_type_id INTEGER, codec TEXT,
+            "index" INTEGER, width INTEGER, height INTEGER, bitrate INTEGER,
+            channels INTEGER, language TEXT, frame_rate REAL,
+            bit_depth INTEGER, sampling_rate INTEGER
+        );
+        INSERT INTO media_items (id) VALUES (100);
+        INSERT INTO media_parts (id, media_item_id, file)
+            VALUES (200, 100, '/strm/test.strm');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def main() -> None:
+    """执行自测流程并打印结果。"""
+    tmp = tempfile.mkdtemp()
+    db = os.path.join(tmp, "com.plexapp.plugins.library.db")
+    build_fake_db(db)
+
+    # 备份测试
+    bak = h.backup_db(db)
+    assert os.path.isfile(bak), "备份失败"
+    print("备份 OK:", bak)
+
+    payload = {
+        "part_id": 200,
+        "container": "mkv",
+        "duration": 1420000,
+        "size": 2147483648,
+        "bitrate": 12000,
+        "width": 1920,
+        "height": 1080,
+        "video_codec": "hevc",
+        "audio_codec": "flac",
+        "frame_rate": 23.976,
+        "audio_channels": 6,
+        "overwrite_streams": True,
+        "streams": [
+            {"stream_type": 1, "codec": "hevc", "index": 0, "width": 1920,
+             "height": 1080, "bitrate": 12000, "frame_rate": 23.976, "bit_depth": 10},
+            {"stream_type": 2, "codec": "flac", "index": 1, "channels": 6,
+             "language": "jpn", "sampling_rate": 48000},
+            {"stream_type": 3, "codec": "srt", "index": 2, "language": "chi"},
+        ],
+    }
+    res = h.write_media_info(db, payload)
+    print("首次写入:", res)
+    assert res["success"], res
+    assert res["streams_written"] == 3, res
+
+    # 校验写入结果
+    conn = sqlite3.connect(db)
+    mi = conn.execute(
+        "SELECT width,height,video_codec,audio_codec,container FROM media_items WHERE id=100"
+    ).fetchone()
+    print("media_items:", mi)
+    assert mi == (1920, 1080, "hevc", "flac", "mkv"), mi
+    ns = conn.execute(
+        "SELECT COUNT(*) FROM media_streams WHERE media_part_id=200"
+    ).fetchone()[0]
+    assert ns == 3, ns
+
+    # 二次写入（overwrite）应先删旧流再写，仍是 3 条
+    res2 = h.write_media_info(db, payload)
+    print("二次写入:", res2)
+    assert res2["streams_deleted"] == 3, res2
+    ns2 = conn.execute(
+        "SELECT COUNT(*) FROM media_streams WHERE media_part_id=200"
+    ).fetchone()[0]
+    assert ns2 == 3, ns2
+    conn.close()
+
+    print("\n全部自测通过 ✅")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins.v3/plextoolbox/helper_client.py
+++ b/plugins.v3/plextoolbox/helper_client.py
@@ -1,0 +1,123 @@
+"""helper 写库服务的 HTTP 客户端封装。"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from httpx import Client
+
+from app.sdk.logging import logger
+
+
+class HelperClient:
+    """封装对 122 上 plex-mediainfo-helper 写库服务的调用。"""
+
+    def __init__(self, base_url: str, token: str = "", timeout: float = 60.0) -> None:
+        """
+        初始化 helper 客户端。
+
+        :param base_url: helper 地址，如 http://192.168.0.122:9001
+        :param token: 访问 token（对应 helper 的 PTH_TOKEN）
+        :param timeout: 请求超时秒数
+        """
+        self._base = base_url.rstrip("/")
+        self._token = token
+        self._timeout = timeout
+
+    def _headers(self) -> Dict[str, str]:
+        """构建带 token 的请求头。"""
+        h = {"Content-Type": "application/json"}
+        if self._token:
+            h["X-PTH-Token"] = self._token
+        return h
+
+    def health(self) -> bool:
+        """
+        健康检查。
+
+        :return: 服务可用返回 True
+        """
+        try:
+            with Client(timeout=10.0) as client:
+                resp = client.get(f"{self._base}/health")
+                return resp.status_code == 200
+        except Exception:
+            return False
+
+    def dbinfo(self) -> Optional[Dict[str, Any]]:
+        """
+        查询 helper 的数据库信息。
+
+        :return: dbinfo 响应，失败返回 None
+        """
+        try:
+            with Client(timeout=15.0) as client:
+                resp = client.get(f"{self._base}/dbinfo", headers=self._headers())
+                if resp.status_code == 200:
+                    return resp.json()
+                logger.warning("helper /dbinfo 返回 %s", resp.status_code)
+        except Exception as e:
+            logger.warning("helper /dbinfo 失败: %s", e)
+        return None
+
+    def write_batch(
+        self, items: List[Dict[str, Any]], force: bool = False
+    ) -> Optional[Dict[str, Any]]:
+        """
+        批量写入媒体信息。
+
+        :param items: 每项为 helper payload（含 part_id 等）
+        :param force: 是否忽略 Plex 繁忙检测强制写入
+        :return: 写入结果，失败返回 None
+        """
+        if not items:
+            return {"success": True, "total": 0, "ok": 0, "results": []}
+        try:
+            with Client(timeout=self._timeout) as client:
+                resp = client.post(
+                    f"{self._base}/write_batch",
+                    headers=self._headers(),
+                    json={"items": items, "force": force},
+                )
+                if resp.status_code in (200, 409):
+                    data = resp.json()
+                    self._log_batch_result(data, len(items))
+                    return data
+                logger.warning(
+                    "helper /write_batch 返回 %s，本批 %s 条全部未写入",
+                    resp.status_code, len(items),
+                )
+        except Exception as e:
+            logger.warning("helper /write_batch 失败: %s（本批 %s 条未写入）", e, len(items))
+        return None
+
+    @staticmethod
+    def _log_batch_result(data: Dict[str, Any], sent: int) -> None:
+        """
+        按 helper 返回结果打印写入成功/失败明细。
+
+        :param data: helper /write_batch 响应体
+        :param sent: 本批发送的条目数
+        """
+        if data.get("busy"):
+            logger.warning(
+                "helper 检测到 Plex 繁忙，本批 %s 条全部未写入（可勾选强制写入或错峰重试）",
+                sent,
+            )
+            return
+        ok = data.get("ok", 0)
+        results = data.get("results") or []
+        failed = [
+            r for r in results
+            if not (r.get("success") or r.get("ok") or r.get("written"))
+        ]
+        if failed:
+            logger.warning("helper 写入完成：成功 %s / 共 %s，失败 %s 条明细：", ok, sent, len(failed))
+            for r in failed[:50]:
+                pid = r.get("part_id") or r.get("id") or "?"
+                reason = r.get("error") or r.get("message") or r.get("reason") or "未知原因"
+                logger.warning("  写入失败 part_id=%s：%s", pid, reason)
+            if len(failed) > 50:
+                logger.warning("  （另有 %s 条失败明细省略）", len(failed) - 50)
+        else:
+            logger.info("helper 写入完成：成功 %s / 共 %s，全部成功", ok, sent)

--- a/plugins.v3/plextoolbox/index.html
+++ b/plugins.v3/plextoolbox/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PlexToolbox</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/plugins.v3/plextoolbox/mediainfo.py
+++ b/plugins.v3/plextoolbox/mediainfo.py
@@ -1,0 +1,315 @@
+"""媒体信息补全编排：枚举 Plex STRM 条目，取数据源，写入 helper。"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Dict, List, Optional
+
+from app.sdk.logging import logger
+
+from .emby_client import EmbyClient
+from .ffprobe_source import FfprobeSource
+from .helper_client import HelperClient
+from .plex_client import PlexClient
+
+
+class MediaInfoCompleter:
+    """编排 Plex STRM 媒体流信息补全的完整流程。"""
+
+    def __init__(
+        self,
+        plex: PlexClient,
+        helper: HelperClient,
+        emby: Optional[EmbyClient] = None,
+        use_emby: bool = True,
+        overwrite_streams: bool = True,
+        concurrency: int = 3,
+        force_write: bool = False,
+        ffprobe: Optional[FfprobeSource] = None,
+        use_ffprobe: bool = True,
+    ) -> None:
+        """
+        初始化补全器。
+
+        :param plex: Plex 客户端
+        :param helper: helper 写库客户端
+        :param emby: Emby 客户端（数据源）
+        :param use_emby: 是否启用 Emby 数据源
+        :param overwrite_streams: 写入前是否清空该 part 旧流
+        :param concurrency: 数据源探测并发数
+        :param force_write: 是否忽略 Plex 繁忙强制写入
+        :param ffprobe: ffprobe 数据源
+        :param use_ffprobe: 是否启用 ffprobe 数据源
+        """
+        self._plex = plex
+        self._helper = helper
+        self._emby = emby
+        self._use_emby = use_emby and emby is not None
+        self._ffprobe = ffprobe
+        self._use_ffprobe = use_ffprobe and ffprobe is not None
+        self._overwrite = overwrite_streams
+        self._concurrency = max(1, concurrency)
+        self._force = force_write
+
+    def _resolve_one(self, part: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        为单个 STRM part 从 Emby 或 ffprobe 解析媒体信息。
+
+        :param part: {part_id, file, title, ...}
+        :return: helper payload（含 part_id 与流信息），失败返回 None
+        """
+        file_path = part.get("file") or ""
+        info: Optional[Dict[str, Any]] = None
+
+        if self._use_emby and self._emby:
+            try:
+                info = self._emby.find_streams_by_name(file_path)
+            except Exception as e:
+                logger.debug("Emby 数据源失败 %s: %s", file_path, e)
+
+        if not info and self._use_ffprobe and self._ffprobe:
+            try:
+                info = self._ffprobe.find_streams_by_name(file_path)
+            except Exception as e:
+                logger.debug("ffprobe 数据源失败 part_id=%s: %s", part.get("part_id"), e)
+
+        if not info:
+            return None
+        info["part_id"] = part["part_id"]
+        info["overwrite_streams"] = self._overwrite
+        return info
+
+    def _log_write_outcome(
+        self,
+        scope: str,
+        sent: int,
+        res: Optional[Dict[str, Any]],
+        summary: Dict[str, Any],
+    ) -> None:
+        """
+        统一打印写入结果日志：区分 helper 无响应 / Plex 繁忙 / 部分失败 / 全部成功。
+
+        :param scope: 日志范围描述，如 "全量补全" 或 "ratingKey=xxx"
+        :param sent: 本次发送写入的条目数
+        :param res: helper.write_batch 返回值
+        :param summary: 当前汇总（用于读取 written_ok/write_failed）
+        """
+        if sent == 0:
+            return
+        if res is None:
+            logger.warning(
+                "PlexToolbox 写入失败[%s]：helper 无响应/请求异常，%s 条全部未写入",
+                scope, sent,
+            )
+            return
+        if res.get("busy"):
+            logger.warning(
+                "PlexToolbox 写入未完成[%s]：Plex 繁忙，%s 条未写入（可勾选强制写入或错峰重试）",
+                scope, sent,
+            )
+            return
+        failed = summary.get("write_failed", 0)
+        ok = summary.get("written_ok", 0)
+        if failed > 0:
+            logger.warning(
+                "PlexToolbox 写入部分失败[%s]：成功 %s / 共 %s，失败 %s 条",
+                scope, ok, sent, failed,
+            )
+        else:
+            logger.info("PlexToolbox 写入成功[%s]：%s 条全部写入", scope, ok)
+
+    def _log_unresolved(self, scope: str, unresolved_files: List[str]) -> None:
+        """
+        打印未能从任何数据源取到媒体信息的文件明细。
+
+        :param scope: 日志范围描述
+        :param unresolved_files: 未解析成功的文件路径列表
+        """
+        if not unresolved_files:
+            return
+        logger.warning(
+            "PlexToolbox 未取到媒体信息[%s]：%s 个文件（Emby/ffprobe 均未命中）",
+            scope, len(unresolved_files),
+        )
+        for f in unresolved_files[:50]:
+            logger.warning("  未解析: %s", f)
+        if len(unresolved_files) > 50:
+            logger.warning("  （另有 %s 个未解析文件省略）", len(unresolved_files) - 50)
+
+    def run_rating_key(
+        self, rating_key: str, only_missing: bool = True, forward: int = 5
+    ) -> Dict[str, Any]:
+        """
+        针对单个播放条目 ratingKey 执行增量补全（用于播放停止后的针对性补全）。
+
+        采用播放驱动的窗口策略：电影仅补当前这部；单集则补「当前集 + 后 forward 集」
+        窗口，only_missing=True 时窗口内已补全的集自动跳过，实现增量。
+
+        :param rating_key: 当前播放条目的 ratingKey（电影或单集）
+        :param only_missing: 是否仅处理缺失媒体信息的 part
+        :param forward: 单集场景下向后预取的集数
+        :return: 汇总结果
+        """
+        summary: Dict[str, Any] = {
+            "rating_key": rating_key,
+            "label": self._plex.item_label(rating_key),
+            "strm_parts": 0,
+            "resolved": 0,
+            "emby_hits": 0,
+            "ffprobe_hits": 0,
+            "unresolved": 0,
+            "written_ok": 0,
+            "write_failed": 0,
+            "helper_busy": False,
+            "items": [],
+        }
+        parts = self._plex.collect_window_parts_by_rating_key(
+            rating_key, forward=forward, only_missing=only_missing
+        )
+        summary["strm_parts"] = len(parts)
+        # 日志范围优先用可读剧名/片名，取不到再退回 ratingKey
+        scope = summary.get("label") or f"ratingKey={rating_key}"
+        if not parts:
+            return summary
+
+        payloads: List[Dict[str, Any]] = []
+        unresolved_files: List[str] = []
+        # part_id -> 明细项引用，写入阶段回填状态
+        item_index: Dict[Any, Dict[str, Any]] = {}
+        for p in parts:
+            item = {
+                "label": p.get("label") or p.get("title") or "",
+                "part_id": p.get("part_id"),
+                "status": "unresolved",
+            }
+            summary["items"].append(item)
+            item_index[p.get("part_id")] = item
+            info = self._resolve_one(p)
+            if info:
+                payloads.append(info)
+                summary["resolved"] += 1
+                item["status"] = "resolved"
+                if info.get("source") == "emby":
+                    summary["emby_hits"] += 1
+                elif info.get("source") == "ffprobe":
+                    summary["ffprobe_hits"] += 1
+            else:
+                summary["unresolved"] += 1
+                unresolved_files.append(p.get("file") or str(p.get("part_id")))
+
+        scope = summary.get("label") or f"ratingKey={rating_key}"
+        self._log_unresolved(scope, unresolved_files)
+
+        for p in payloads:
+            p.pop("source", None)
+        if payloads:
+            res = self._helper.write_batch(payloads, force=self._force)
+            if res is None:
+                summary["write_failed"] = len(payloads)
+                for p in payloads:
+                    it = item_index.get(p.get("part_id"))
+                    if it:
+                        it["status"] = "write_failed"
+            elif res.get("busy"):
+                summary["helper_busy"] = True
+                summary["write_failed"] = len(payloads)
+                for p in payloads:
+                    it = item_index.get(p.get("part_id"))
+                    if it:
+                        it["status"] = "busy"
+            else:
+                summary["written_ok"] = res.get("ok", 0)
+                summary["write_failed"] = len(payloads) - res.get("ok", 0)
+                # 按 helper 返回的逐条结果回填写入状态
+                for r in res.get("results") or []:
+                    it = item_index.get(r.get("part_id"))
+                    if it:
+                        it["status"] = "written" if r.get("success") else "write_failed"
+                        if not r.get("success") and r.get("error"):
+                            it["error"] = str(r.get("error"))[:120]
+            self._log_write_outcome(scope, len(payloads), res, summary)
+        return summary
+
+    def run(
+        self,
+        section_keys: List[str],
+        only_missing: bool = True,
+        progress_cb: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> Dict[str, Any]:
+        """
+        执行补全：枚举分区 STRM part，解析数据源并写入 helper。
+
+        :param section_keys: 要处理的 Plex 分区 key 列表
+        :param only_missing: 是否仅处理缺失媒体信息的 part
+        :param progress_cb: 进度回调（收到阶段性统计）
+        :return: 汇总结果
+        """
+        summary: Dict[str, Any] = {
+            "sections": len(section_keys),
+            "strm_parts": 0,
+            "resolved": 0,
+            "emby_hits": 0,
+            "ffprobe_hits": 0,
+            "unresolved": 0,
+            "written_ok": 0,
+            "write_failed": 0,
+            "helper_busy": False,
+            "details": [],
+        }
+
+        # 1. 枚举 STRM part
+        all_parts: List[Dict[str, Any]] = []
+        for skey in section_keys:
+            all_parts.extend(self._plex.collect_strm_parts(skey, only_missing))
+        summary["strm_parts"] = len(all_parts)
+        if not all_parts:
+            return summary
+        if progress_cb:
+            progress_cb({"phase": "enumerated", "count": len(all_parts)})
+
+        # 2. 并发解析数据源
+        payloads: List[Dict[str, Any]] = []
+        unresolved_files: List[str] = []
+        with ThreadPoolExecutor(max_workers=self._concurrency) as pool:
+            futures = {pool.submit(self._resolve_one, p): p for p in all_parts}
+            done = 0
+            for fut in as_completed(futures):
+                done += 1
+                src_part = futures[fut]
+                info = fut.result()
+                if info:
+                    payloads.append(info)
+                    summary["resolved"] += 1
+                    if info.get("source") == "emby":
+                        summary["emby_hits"] += 1
+                    elif info.get("source") == "ffprobe":
+                        summary["ffprobe_hits"] += 1
+                else:
+                    summary["unresolved"] += 1
+                    unresolved_files.append(
+                        src_part.get("file") or str(src_part.get("part_id"))
+                    )
+                if progress_cb and done % 10 == 0:
+                    progress_cb(
+                        {"phase": "resolving", "done": done, "total": len(all_parts)}
+                    )
+
+        self._log_unresolved("全量补全", unresolved_files)
+
+        # 3. 写入 helper（去掉 source 字段再发）
+        for p in payloads:
+            p.pop("source", None)
+        if payloads:
+            res = self._helper.write_batch(payloads, force=self._force)
+            if res is None:
+                summary["write_failed"] = len(payloads)
+            elif res.get("busy"):
+                summary["helper_busy"] = True
+                summary["write_failed"] = len(payloads)
+            else:
+                summary["written_ok"] = res.get("ok", 0)
+                summary["write_failed"] = len(payloads) - res.get("ok", 0)
+            self._log_write_outcome("全量补全", len(payloads), res, summary)
+        if progress_cb:
+            progress_cb({"phase": "done", **summary})
+        return summary

--- a/plugins.v3/plextoolbox/package-lock.json
+++ b/plugins.v3/plextoolbox/package-lock.json
@@ -1,0 +1,1225 @@
+{
+  "name": "plextoolbox-ui",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plextoolbox-ui",
+      "version": "1.1.0",
+      "dependencies": {
+        "@originjs/vite-plugin-federation": "^1.4.1",
+        "@vitejs/plugin-vue": "^5.0.4",
+        "vite": "^5.4.11",
+        "vue": "^3.5.13",
+        "vuetify": "3.7.3"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@originjs/vite-plugin-federation": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@originjs/vite-plugin-federation/-/vite-plugin-federation-1.4.1.tgz",
+      "integrity": "sha512-Uo08jW5pj1t58OUKuZNkmzcfTN2pqeVuAWCCiKf/75/oll4Efq4cHOqSE1FXMlvwZNGDziNdDyBbQ5IANem3CQ==",
+      "license": "MulanPSL-2.0",
+      "dependencies": {
+        "estree-walker": "^3.0.2",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "pnpm": ">=7.0.1"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "vue": "3.5.39"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vuetify": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.3.tgz",
+      "integrity": "sha512-bpuvBpZl1/+nLlXDgdVXekvMNR6W/ciaoa8CYlpeAzAARbY8zUFSoBq05JlLhkIHI58AnzKVy4c09d0OtfYAPg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/johnleider"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7",
+        "vite-plugin-vuetify": ">=1.0.0",
+        "vue": "^3.3.0",
+        "webpack-plugin-vuetify": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vite-plugin-vuetify": {
+          "optional": true
+        },
+        "webpack-plugin-vuetify": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/plugins.v3/plextoolbox/package.json
+++ b/plugins.v3/plextoolbox/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "plextoolbox-ui",
+  "private": true,
+  "version": "1.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@originjs/vite-plugin-federation": "^1.4.1",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "vite": "^5.4.11",
+    "vue": "^3.5.13",
+    "vuetify": "3.7.3"
+  },
+  "devDependencies": {}
+}

--- a/plugins.v3/plextoolbox/plex_client.py
+++ b/plugins.v3/plextoolbox/plex_client.py
@@ -1,0 +1,530 @@
+"""Plex API 轻封装：枚举媒体库、列出条目、抽取 STRM part 信息。"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+from urllib.parse import quote
+
+from httpx import Client
+
+from app.sdk.logging import logger
+
+
+class PlexClient:
+    """封装 Plex 服务器只读查询，用于枚举需要补全媒体信息的 STRM 条目。"""
+
+    def __init__(self, base_url: str, token: str, timeout: float = 30.0) -> None:
+        """
+        初始化 Plex 客户端。
+
+        :param base_url: Plex 服务器根地址（可直连真实后端，如 http://192.168.0.122:32400）
+        :param token: X-Plex-Token
+        :param timeout: 请求超时秒数
+        """
+        self._base = base_url.rstrip("/")
+        self._token = token
+        self._timeout = timeout
+
+    def _get(self, path: str) -> Optional[dict]:
+        """
+        发起 GET 请求并解析 JSON。
+
+        :param path: 相对路径（含查询串）
+        :return: 解析后的 JSON，失败返回 None
+        """
+        sep = "&" if "?" in path else "?"
+        url = f"{self._base}{path}{sep}X-Plex-Token={quote(self._token, safe='')}"
+        try:
+            with Client(timeout=self._timeout) as client:
+                resp = client.get(url, headers={"Accept": "application/json"})
+                if resp.status_code == 200:
+                    return resp.json()
+                logger.warning("Plex API %s 返回 %s", path, resp.status_code)
+        except Exception as e:
+            logger.warning("Plex API 请求失败 %s: %s", path, e)
+        return None
+
+    def _put(self, path: str) -> bool:
+        """
+        发起 PUT 请求（用于 unmatch 等写操作）。
+
+        :param path: 相对路径（含查询串）
+        :return: 2xx 返回 True
+        """
+        sep = "&" if "?" in path else "?"
+        url = f"{self._base}{path}{sep}X-Plex-Token={quote(self._token, safe='')}"
+        try:
+            with Client(timeout=self._timeout) as client:
+                resp = client.put(url, headers={"Accept": "application/json"})
+                if 200 <= resp.status_code < 300:
+                    return True
+                logger.warning("Plex PUT %s 返回 %s", path, resp.status_code)
+        except Exception as e:
+            logger.warning("Plex PUT 请求失败 %s: %s", path, e)
+        return False
+
+    def section_type(self, section_key: str) -> str:
+        """
+        获取分区类型（movie/show 等）。
+
+        :param section_key: 分区 key
+        :return: 类型字符串，未知返回空串
+        """
+        for s in self.list_sections():
+            if str(s.get("key")) == str(section_key):
+                return s.get("type") or ""
+        return ""
+
+    def iter_top_items(self, section_key: str) -> List[Dict[str, Any]]:
+        """
+        列出分区下顶层条目（电影或剧集），带封面标记与文件路径信息。
+
+        :param section_key: 分区 key
+        :return: [{rating_key, type, title, has_thumb, has_art}]
+        """
+        data = self._get(f"/library/sections/{section_key}/all")
+        if not data:
+            return []
+        items = data.get("MediaContainer", {}).get("Metadata", [])
+        result: List[Dict[str, Any]] = []
+        for m in items:
+            if not m.get("ratingKey"):
+                continue
+            result.append(
+                {
+                    "rating_key": m.get("ratingKey"),
+                    "type": m.get("type"),
+                    "title": m.get("title"),
+                    "has_thumb": bool(m.get("thumb")),
+                    "has_art": bool(m.get("art")),
+                }
+            )
+        return result
+
+    def unmatch(self, rating_key: str) -> bool:
+        """
+        取消某条目的匹配（打回未匹配，重读时按当前代理识别）。
+
+        :param rating_key: 条目 ratingKey
+        :return: 成功返回 True
+        """
+        return self._put(f"/library/metadata/{rating_key}/unmatch")
+
+    def refresh_metadata(self, rating_key: str) -> bool:
+        """
+        触发条目按当前代理刷新元数据（用于 unmatch 后重读 NFO）。
+
+        :param rating_key: 条目 ratingKey
+        :return: 成功返回 True
+        """
+        return self._put(f"/library/metadata/{rating_key}/refresh")
+
+    def first_file_path(self, rating_key: str, item_type: str) -> str:
+        """
+        取条目第一个媒体文件的真实路径（用于定位 STRM 目录）。
+
+        电影直接取自身 Part；剧集下钻到第一集取 Part。
+
+        :param rating_key: 条目 ratingKey
+        :param item_type: 条目类型（movie/show）
+        :return: 文件路径，取不到返回空串
+        """
+        metas: List[Dict[str, Any]] = []
+        if item_type == "show":
+            for season in self._children(rating_key):
+                skey = season.get("ratingKey")
+                if not skey:
+                    continue
+                eps = self._children(skey)
+                if eps:
+                    metas = self._metadata(eps[0].get("ratingKey"))
+                    break
+        else:
+            metas = self._metadata(rating_key)
+        for meta in metas:
+            for p in self._extract_parts(meta):
+                if p.get("file"):
+                    return p["file"]
+        return ""
+
+    def list_sections(self) -> List[Dict[str, Any]]:
+        """
+        列出所有媒体库分区。
+
+        :return: [{key, title, type}]，type 为 movie/show 等
+        """
+        data = self._get("/library/sections")
+        if not data:
+            return []
+        dirs = data.get("MediaContainer", {}).get("Directory", [])
+        return [
+            {"key": d.get("key"), "title": d.get("title"), "type": d.get("type")}
+            for d in dirs
+            if d.get("key")
+        ]
+
+    def _iter_section_items(self, section_key: str) -> List[Dict[str, Any]]:
+        """
+        列出某分区下全部条目的 ratingKey 与类型。
+
+        :param section_key: 分区 key
+        :return: [{rating_key, type, title}]
+        """
+        data = self._get(f"/library/sections/{section_key}/all")
+        if not data:
+            return []
+        items = data.get("MediaContainer", {}).get("Metadata", [])
+        return [
+            {
+                "rating_key": m.get("ratingKey"),
+                "type": m.get("type"),
+                "title": m.get("title"),
+            }
+            for m in items
+            if m.get("ratingKey")
+        ]
+
+    def _metadata(self, rating_key: str) -> List[Dict[str, Any]]:
+        """
+        获取条目元数据的 Metadata 数组。
+
+        :param rating_key: 条目 ratingKey
+        :return: Metadata 列表
+        """
+        data = self._get(f"/library/metadata/{rating_key}")
+        if not data:
+            return []
+        return data.get("MediaContainer", {}).get("Metadata", [])
+
+    def _children(self, rating_key: str) -> List[Dict[str, Any]]:
+        """
+        获取条目的子项（剧集的季、季的集）。
+
+        :param rating_key: 父条目 ratingKey
+        :return: 子项 Metadata 列表
+        """
+        data = self._get(f"/library/metadata/{rating_key}/children")
+        if not data:
+            return []
+        return data.get("MediaContainer", {}).get("Metadata", [])
+
+    @staticmethod
+    def _build_label(metadata: Dict[str, Any]) -> str:
+        """
+        构建条目的人类可读标签：剧集为「剧名 SxxExx 集名」，电影为「片名 (年份)」。
+
+        :param metadata: 条目 Metadata
+        :return: 标签字符串
+        """
+        title = metadata.get("title") or ""
+        if metadata.get("type") == "episode":
+            show = metadata.get("grandparentTitle") or ""
+            s, e = metadata.get("parentIndex"), metadata.get("index")
+            se = ""
+            try:
+                if s is not None and e is not None:
+                    se = f"S{int(s):02d}E{int(e):02d}"
+            except (TypeError, ValueError):
+                se = ""
+            return " ".join(x for x in (show, se, title) if x)
+        year = metadata.get("year")
+        return f"{title} ({year})" if year else title
+
+    def item_label(self, rating_key: str) -> str:
+        """
+        取单个条目的可读标签（用于补全结果展示）。
+
+        :param rating_key: 条目 ratingKey
+        :return: 标签，取不到返回空串
+        """
+        metas = self._metadata(rating_key)
+        return self._build_label(metas[0]) if metas else ""
+
+    def item_section_key(self, rating_key: str) -> str:
+        """返回单个条目所属的 Plex 媒体库 key。"""
+        metas = self._metadata(rating_key)
+        if not metas:
+            return ""
+        meta = metas[0]
+        return str(
+            meta.get("librarySectionID")
+            or meta.get("librarySectionKey")
+            or ""
+        ).strip()
+
+    @staticmethod
+    def _extract_parts(metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        从单个条目元数据中抽取所有 Part 的关键字段。
+
+        :param metadata: 条目 Metadata
+        :return: [{part_id, file, container, title, label, duration_hint}]
+        """
+        result: List[Dict[str, Any]] = []
+        title = metadata.get("title") or ""
+        label = PlexClient._build_label(metadata)
+        for media in metadata.get("Media", []) or []:
+            for part in media.get("Part", []) or []:
+                pid = part.get("id")
+                pfile = part.get("file")
+                if pid and pfile:
+                    result.append(
+                        {
+                            "part_id": pid,
+                            "file": pfile,
+                            "container": part.get("container"),
+                            "title": title,
+                            "label": label,
+                            "existing_duration": part.get("duration"),
+                            # children 列表接口的 Part 不含 Stream 字段，
+                            # 置 None 表示未知，区别于确认为空的 0
+                            "existing_streams": (
+                                len(part.get("Stream") or [])
+                                if "Stream" in part else None
+                            ),
+                        }
+                    )
+        return result
+
+    def collect_strm_parts(
+        self, section_key: str, only_missing: bool = True
+    ) -> List[Dict[str, Any]]:
+        """
+        枚举某分区下所有 STRM 文件对应的 Part 信息。
+
+        对电影分区直接取条目 Part；对剧集分区逐层下钻到集再取 Part。
+        only_missing 为 True 时仅返回缺失媒体流信息（无 Stream 或无时长）的 part。
+
+        :param section_key: 分区 key
+        :param only_missing: 是否仅返回缺失媒体信息的 part
+        :return: STRM part 列表
+        """
+        parts: List[Dict[str, Any]] = []
+        for item in self._iter_section_items(section_key):
+            rating_key = item["rating_key"]
+            itype = item.get("type")
+            if itype in ("show",):
+                # 剧集：show -> season -> episode
+                for season in self._children(rating_key):
+                    skey = season.get("ratingKey")
+                    if not skey:
+                        continue
+                    for episode in self._children(skey):
+                        parts.extend(self._collect_from_meta(episode, only_missing))
+            else:
+                for meta in self._metadata(rating_key):
+                    parts.extend(
+                        self._collect_from_meta(meta, only_missing, detailed=True)
+                    )
+        return parts
+
+    def collect_strm_parts_by_rating_key(
+        self, rating_key: str, only_missing: bool = True
+    ) -> List[Dict[str, Any]]:
+        """
+        按单个条目 ratingKey 枚举其 STRM part（用于播放停止后的针对性补全）。
+
+        播放上报/Webhook 给到的 ratingKey 通常是叶子条目（电影或单集），
+        直接取其元数据 Part 即可，无需下钻季/集。
+
+        :param rating_key: 条目 ratingKey
+        :param only_missing: 是否仅返回缺失媒体信息的 part
+        :return: STRM part 列表
+        """
+        parts: List[Dict[str, Any]] = []
+        for meta in self._metadata(rating_key):
+            parts.extend(self._collect_from_meta(meta, only_missing, detailed=True))
+        return parts
+
+    def collect_window_parts_by_rating_key(
+        self,
+        rating_key: str,
+        forward: int = 5,
+        only_missing: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """
+        播放驱动的增量窗口收集：给定当前播放条目，返回需补全的 STRM part。
+
+        规则：
+        - 电影：仅收当前这一条（不做预取）。
+        - 单集：以当前集为起点，向后取 forward 集（含当前集，共 forward+1 集）
+          组成窗口，收集窗口内各集的 STRM part。窗口不跨季，季末即止。
+        - only_missing=True 时，窗口内已有媒体信息（已补全）的集自动跳过，
+          从而实现「命中已写过的跳过、只写新缺集」的增量效果。
+
+        :param rating_key: 当前播放条目的 ratingKey（电影或单集）
+        :param forward: 单集场景下向后预取的集数
+        :param only_missing: 是否仅返回缺失媒体信息的 part
+        :return: 窗口内待补全的 STRM part 列表
+        """
+        metas = self._metadata(rating_key)
+        if not metas:
+            return []
+        meta = metas[0]
+        itype = meta.get("type")
+
+        # 电影或非剧集叶子：仅当前条目
+        if itype != "episode":
+            parts: List[Dict[str, Any]] = []
+            for m in metas:
+                parts.extend(self._collect_from_meta(m, only_missing, detailed=True))
+            return parts
+
+        # 单集：定位所在季，按集号取「当前集 + 后 forward 集」窗口
+        season_key = meta.get("parentRatingKey")
+        cur_index = meta.get("index")
+        if not season_key or cur_index is None:
+            # 缺少定位信息时退化为仅当前集
+            return self._collect_from_meta(meta, only_missing, detailed=True)
+
+        siblings = self._children(season_key)
+        # 按集号排序，过滤出当前集及其后 forward 集
+        indexed = [
+            e for e in siblings
+            if e.get("ratingKey") and e.get("index") is not None
+        ]
+        indexed.sort(key=lambda e: e.get("index"))
+        window = [
+            e for e in indexed
+            if cur_index <= e.get("index") <= cur_index + forward
+        ]
+        if not window:
+            window = [meta]
+
+        parts = []
+        for e in window:
+            ek = e.get("ratingKey")
+            if not ek:
+                continue
+            for m in self._metadata(ek):
+                parts.extend(self._collect_from_meta(m, only_missing, detailed=True))
+        return parts
+
+
+    def _collect_from_meta(
+        self, metadata: Dict[str, Any], only_missing: bool, detailed: bool = False
+    ) -> List[Dict[str, Any]]:
+        """
+        从条目元数据抽取 STRM part，按需过滤已有媒体信息的项。
+
+        :param metadata: 条目 Metadata
+        :param only_missing: 是否仅返回缺失媒体信息的 part
+        :param detailed: metadata 是否来自详情接口（/library/metadata/{rk}）。
+            详情接口会返回 Stream；缺失即代表真的没有流（如被 Plex 清空），
+            需要重写。列表/children 接口不含 Stream，缺失代表未知。
+        :return: STRM part 列表
+        """
+        out: List[Dict[str, Any]] = []
+        for p in self._extract_parts(metadata):
+            fpath = (p.get("file") or "").lower()
+            if not fpath.endswith(".strm"):
+                continue
+            if only_missing and p.get("existing_duration"):
+                streams = p.get("existing_streams")
+                if detailed:
+                    # 详情数据：有时长且流数 >0 才算已补全
+                    if streams:
+                        continue
+                else:
+                    # 列表数据：流数未知(None)时沿用时长判断，避免全库重扫
+                    if streams is None or streams > 0:
+                        continue
+            out.append(p)
+        return out
+
+    @staticmethod
+    def _external_guid(guids: List[Dict[str, Any]]) -> Optional[str]:
+        """
+        从条目的 Guid 数组中提取 tmdb id。
+
+        Plex 的 Guid 形如 ``{"id": "tmdb://94664"}``，这里只取 tmdb 段。
+        电影与剧集共用 tmdb id 作为去重依据。
+
+        :param guids: Plex 条目 Guid 数组
+        :return: tmdb id 字符串，取不到返回 None
+        """
+        for g in guids or []:
+            idv = g.get("id") or ""
+            m = re.search(r"tmdb://(\d+)", idv)
+            if m:
+                return m.group(1)
+        return None
+
+    def scan_duplicate_items(
+        self, media_types: Optional[tuple] = ("movie", "show")
+    ) -> List[Dict[str, Any]]:
+        """
+        扫描媒体库中 tmdb id 相同的重复条目。
+
+        列表接口的 includeGuids 不可靠，这里对每个顶层条目逐个调用详情接口
+        确认外部 GUID，再按 tmdb id 分组，返回重复组供前端确认后合并。
+
+        :param media_types: 限定媒体类型，默认 ("movie", "show")
+        :return: [{guid_id, media_type, title, items:[{rating_key, title, year, leaf_count, section_key, section_title}]}]
+        """
+        wanted = set(media_types or ())
+        grouped: Dict[str, Dict[str, Any]] = {}
+        for sec in self.list_sections():
+            stype = sec.get("type") or ""
+            if wanted and stype not in wanted:
+                continue
+            skey = str(sec.get("key") or "")
+            stitle = sec.get("title") or ""
+            if not skey:
+                continue
+            for item in self._iter_section_items(skey):
+                rk = str(item.get("rating_key") or "")
+                if not rk:
+                    continue
+                metas = self._metadata(rk)
+                if not metas:
+                    continue
+                meta = metas[0]
+                guid_id = self._external_guid(meta.get("Guid") or [])
+                if not guid_id:
+                    continue
+                entry = {
+                    "rating_key": rk,
+                    "title": meta.get("title") or "",
+                    "year": meta.get("year"),
+                    "leaf_count": meta.get("leafCount") or 0,
+                    "section_key": skey,
+                    "section_title": stitle,
+                }
+                bucket = grouped.setdefault(
+                    guid_id,
+                    {
+                        "guid_id": guid_id,
+                        "media_type": stype,
+                        "title": meta.get("title") or "",
+                        "items": [],
+                    },
+                )
+                bucket["items"].append(entry)
+
+        result: List[Dict[str, Any]] = []
+        for bucket in grouped.values():
+            if len(bucket["items"]) < 2:
+                continue
+            # 标题取集数/条目数最多的那个条目，避免误用残缺副本的名称
+            top = max(bucket["items"], key=lambda x: int(x.get("leaf_count") or 0))
+            bucket["title"] = top["title"]
+            bucket["items"].sort(
+                key=lambda x: int(x.get("leaf_count") or 0), reverse=True
+            )
+            result.append(bucket)
+        return result
+
+    def merge_items(self, primary: str, others: List[str]) -> bool:
+        """
+        将多个条目合并到主条目（主条目保留，其余条目并入）。
+
+        :param primary: 保留的主条目 ratingKey
+        :param others: 需并入的条目 ratingKey 列表
+        :return: 成功返回 True
+        """
+        ids = ",".join(str(x) for x in others if str(x))
+        if not ids:
+            return False
+        return self._put(f"/library/metadata/{primary}/merge?ids={ids}")

--- a/plugins.v3/plextoolbox/poster_fixer.py
+++ b/plugins.v3/plextoolbox/poster_fixer.py
@@ -1,0 +1,379 @@
+"""缺 poster.jpg 修复：扫描并为缺封面的电影/剧集补齐剧根/影片级 poster.jpg。
+
+场景：
+- 电影目录有 backdrop/fanart 等图但独缺 poster.jpg → Plex 显示无封面。
+- 剧集剧根缺 poster.jpg，但季目录 Season X/poster.jpg 存在（季海报）→ 剧集列表无封面。
+
+修复策略：
+- 电影：从目录名 {tmdb-xxx} 拉 TMDB movie 海报写 poster.jpg，
+  选图优先级：原产语言 original_language → 中文 zh → 无字 null → 任意最高分。
+- 剧集：优先把季内 Season X/poster.jpg（优先 Season 1）复制到剧根；季内没有再退回
+  TMDB tv 海报（同上优先级）。
+  注意：剧根的 seasonXX-poster.jpg 是季海报命名，不算剧根海报，也不作为复制来源。
+
+写入采用临时文件 + os.replace 原子落地，属主/权限对齐同目录既有图片。
+修复后触发 Plex refresh 让封面生效。
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from typing import Any, Dict, List, Optional, Tuple
+
+from httpx import Client
+
+from app.sdk.config import settings
+from app.sdk.logging import logger
+
+from .plex_client import PlexClient
+
+# 剧根/影片级有效海报文件名（小写比较）；seasonXX-poster.jpg 不算
+ROOT_POSTER_NAMES = ("poster.jpg", "poster.png", "folder.jpg", "cover.jpg", "show.jpg")
+TMDB_DIR_RE = re.compile(r"\{tmdb-(\d+)\}")
+SEASON_DIR_RE = re.compile(r"^season[ _]?(\d+)$", re.IGNORECASE)
+
+
+def _dir_has_root_poster(dir_path: str) -> bool:
+    """
+    判断目录是否已有剧根/影片级海报文件。
+
+    :param dir_path: 目录绝对路径
+    :return: 已有海报返回 True
+    """
+    try:
+        for name in os.listdir(dir_path):
+            if name.lower() in ROOT_POSTER_NAMES:
+                return True
+    except OSError as exc:
+        logger.debug("读取目录失败 %s: %s", dir_path, exc)
+    return False
+
+
+def _extract_tmdbid(dir_path: str) -> Optional[int]:
+    """
+    从目录路径中提取 {tmdb-xxxx} 的 TMDB ID。
+
+    :param dir_path: 目录路径
+    :return: TMDB ID，无则 None
+    """
+    m = TMDB_DIR_RE.search(os.path.basename(dir_path)) or TMDB_DIR_RE.search(dir_path)
+    return int(m.group(1)) if m else None
+
+
+def _find_season_poster(show_dir: str) -> Optional[str]:
+    """
+    在剧根下寻找季目录内的 poster.jpg（优先季号最小的季）。
+
+    :param show_dir: 剧根目录
+    :return: 季内 poster.jpg 路径，找不到返回 None
+    """
+    seasons: List[Tuple[int, str]] = []
+    try:
+        for name in os.listdir(show_dir):
+            sub = os.path.join(show_dir, name)
+            if not os.path.isdir(sub):
+                continue
+            m = SEASON_DIR_RE.match(name)
+            if m:
+                seasons.append((int(m.group(1)), sub))
+    except OSError as exc:
+        logger.debug("读取剧根失败 %s: %s", show_dir, exc)
+        return None
+    for _, sdir in sorted(seasons, key=lambda x: x[0]):
+        for cand in ("poster.jpg", "poster.png"):
+            p = os.path.join(sdir, cand)
+            if os.path.isfile(p):
+                return p
+    return None
+
+
+def _align_owner_perm(target: str, ref_dir: str) -> None:
+    """
+    将 target 的属主/权限对齐 ref_dir 中既有图片文件；无参照时 0644。
+
+    :param target: 目标文件路径
+    :param ref_dir: 参照目录
+    """
+    ref: Optional[os.stat_result] = None
+    try:
+        for name in os.listdir(ref_dir):
+            if name.lower().endswith((".jpg", ".png")) and \
+                    os.path.abspath(os.path.join(ref_dir, name)) != os.path.abspath(target):
+                ref = os.stat(os.path.join(ref_dir, name))
+                break
+    except OSError:
+        pass
+    try:
+        if ref:
+            os.chown(target, ref.st_uid, ref.st_gid)
+            os.chmod(target, ref.st_mode & 0o777)
+        else:
+            os.chmod(target, 0o644)
+    except OSError as exc:
+        logger.debug("对齐属主权限失败 %s: %s", target, exc)
+
+
+def _atomic_write(target: str, data: bytes) -> None:
+    """
+    临时文件 + os.replace 原子写入。
+
+    :param target: 目标路径
+    :param data: 文件内容
+    """
+    tmp = target + ".tmp"
+    with open(tmp, "wb") as f:
+        f.write(data)
+    os.replace(tmp, target)
+
+
+class TmdbPosterSource:
+    """按「原产语言 → zh → 无字 → 任意」优先级从 TMDB 取海报。"""
+
+    def __init__(self, timeout: float = 30.0) -> None:
+        """
+        初始化 TMDB 海报源。
+
+        :param timeout: 请求超时秒数
+        """
+        self._api = f"https://{settings.TMDB_API_DOMAIN}/3"
+        self._img = f"https://{settings.TMDB_IMAGE_DOMAIN}/t/p/original"
+        self._key = settings.TMDB_API_KEY
+        self._proxy = None
+        try:
+            proxies = settings.PROXY
+            if isinstance(proxies, dict):
+                self._proxy = proxies.get("https") or proxies.get("http")
+            elif isinstance(proxies, str):
+                self._proxy = proxies
+        except Exception:
+            self._proxy = None
+        self._timeout = timeout
+
+    def _client(self) -> Client:
+        """构建 httpx 客户端（httpx>=0.28 使用 proxy 参数）。"""
+        return Client(timeout=self._timeout, proxy=self._proxy)
+
+    def _get_json(self, path: str) -> Optional[dict]:
+        """
+        GET TMDB API 并解析 JSON。
+
+        :param path: 相对路径（不含 api_key）
+        :return: JSON，失败返回 None
+        """
+        sep = "&" if "?" in path else "?"
+        url = f"{self._api}{path}{sep}api_key={self._key}"
+        try:
+            with self._client() as client:
+                resp = client.get(url)
+                if resp.status_code == 200:
+                    return resp.json()
+                logger.warning("TMDB %s 返回 %s", path, resp.status_code)
+        except Exception as exc:
+            logger.warning("TMDB 请求失败 %s: %s", path, exc)
+        return None
+
+    @staticmethod
+    def _pick(posters: List[dict], lang: Optional[str]) -> Optional[str]:
+        """
+        在海报列表中按语言过滤并取评分最高的一张。
+
+        :param posters: TMDB posters 列表
+        :param lang: 语言代码；None 表示无字（iso_639_1 为 null）
+        :return: poster file_path，无匹配返回 None
+        """
+        group = [p for p in posters if p.get("iso_639_1") == lang]
+        if not group:
+            return None
+        group.sort(
+            key=lambda p: (p.get("vote_average") or 0, p.get("vote_count") or 0),
+            reverse=True,
+        )
+        return group[0].get("file_path")
+
+    def fetch_poster(self, tmdbid: int, media: str) -> Optional[bytes]:
+        """
+        取指定条目的最佳海报图片字节。
+
+        :param tmdbid: TMDB ID
+        :param media: 'movie' 或 'tv'
+        :return: 图片字节，失败返回 None
+        """
+        detail = self._get_json(f"/{media}/{tmdbid}")
+        if not detail:
+            return None
+        orig_lang = detail.get("original_language")
+        images = self._get_json(f"/{media}/{tmdbid}/images")
+        posters = (images or {}).get("posters") or []
+        file_path = None
+        for lang in (orig_lang, "zh", None):
+            file_path = self._pick(posters, lang)
+            if file_path:
+                break
+        if not file_path:
+            # images 无结果时退回 detail 的默认 poster_path
+            file_path = detail.get("poster_path")
+        if not file_path:
+            return None
+        url = f"{self._img}{file_path}"
+        try:
+            with self._client() as client:
+                resp = client.get(url)
+                if resp.status_code == 200 and resp.content:
+                    return resp.content
+                logger.warning("TMDB 海报下载失败 %s: %s", url, resp.status_code)
+        except Exception as exc:
+            logger.warning("TMDB 海报下载异常 %s: %s", url, exc)
+        return None
+
+
+class PosterFixer:
+    """编排「缺 poster.jpg 扫描 + 补全 + Plex 刷新」流程。"""
+
+    def __init__(self, plex: PlexClient) -> None:
+        """
+        初始化。
+
+        :param plex: Plex 客户端（直连）
+        """
+        self._plex = plex
+        self._tmdb = TmdbPosterSource()
+
+    def _media_dir(self, rating_key: str, itype: str) -> str:
+        """
+        根据条目类型定位媒体目录（电影=文件上级；剧集=文件上两级即剧根）。
+
+        :param rating_key: 条目 ratingKey
+        :param itype: 分区类型 movie/show
+        :return: 目录路径，取不到返回空串
+        """
+        file_path = self._plex.first_file_path(rating_key, itype)
+        if not file_path:
+            return ""
+        if itype == "show":
+            return os.path.dirname(os.path.dirname(file_path))
+        return os.path.dirname(file_path)
+
+    def scan(self, section_key: str) -> Dict[str, Any]:
+        """
+        扫描分区内「目录缺剧根/影片级 poster.jpg」的条目。
+
+        :param section_key: Plex 分区 key
+        :return: {checked, total, missing: [{rating_key, title, dir, tmdbid, media}]}
+        """
+        itype = self._plex.section_type(section_key)
+        media = "tv" if itype == "show" else "movie"
+        items = self._plex.iter_top_items(section_key)
+        missing: List[Dict[str, Any]] = []
+        for it in items:
+            rk = it["rating_key"]
+            d = self._media_dir(rk, itype)
+            if not d or not os.path.isdir(d):
+                continue
+            if _dir_has_root_poster(d):
+                continue
+            missing.append(
+                {
+                    "rating_key": rk,
+                    "title": it.get("title"),
+                    "dir": d,
+                    "tmdbid": _extract_tmdbid(d),
+                    "media": media,
+                }
+            )
+        return {
+            "section": section_key,
+            "type": itype,
+            "checked": len(items),
+            "total": len(missing),
+            "missing": missing,
+        }
+
+    def _fix_one(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        修复单个缺 poster 条目。
+
+        :param item: scan 产出的 missing 项
+        :return: {ok, source, error?}
+        """
+        d = item["dir"]
+        target = os.path.join(d, "poster.jpg")
+        # TV 优先季内复制
+        if item.get("media") == "tv":
+            season_poster = _find_season_poster(d)
+            if season_poster:
+                try:
+                    tmp = target + ".tmp"
+                    shutil.copyfile(season_poster, tmp)
+                    os.replace(tmp, target)
+                    _align_owner_perm(target, d)
+                    return {"ok": True, "source": "season_copy"}
+                except OSError as exc:
+                    logger.warning("季海报复制失败 %s: %s", d, exc)
+        # TMDB 回退
+        tmdbid = item.get("tmdbid")
+        if not tmdbid:
+            return {"ok": False, "error": "目录名无 {tmdb-id}，且无季内海报可用"}
+        data = self._tmdb.fetch_poster(tmdbid, item.get("media") or "movie")
+        if not data:
+            return {"ok": False, "error": f"TMDB 未取到海报 (tmdbid={tmdbid})"}
+        try:
+            _atomic_write(target, data)
+            _align_owner_perm(target, d)
+            return {"ok": True, "source": "tmdb"}
+        except OSError as exc:
+            return {"ok": False, "error": f"写入失败: {exc}"}
+
+    def fix(
+        self, section_key: str, dry_run: bool = True, limit: int = 0
+    ) -> Dict[str, Any]:
+        """
+        对分区执行缺 poster 补全：扫描 → 补全 → Plex refresh。
+
+        :param section_key: Plex 分区 key
+        :param dry_run: 为 True 时仅列出待修复条目，不写入
+        :param limit: 最多处理条数，0 表示不限制
+        :return: 汇总结果
+        """
+        scan = self.scan(section_key)
+        targets = scan["missing"]
+        if limit:
+            targets = targets[:limit]
+        summary: Dict[str, Any] = {
+            "section": section_key,
+            "type": scan["type"],
+            "dry_run": dry_run,
+            "checked": scan["checked"],
+            "candidates": len(targets),
+            "fixed": 0,
+            "failed": 0,
+            "refreshed": 0,
+            "details": [],
+        }
+        if dry_run:
+            summary["targets"] = [
+                {"title": t["title"], "dir": t["dir"], "tmdbid": t["tmdbid"]}
+                for t in targets
+            ]
+            return summary
+        for t in targets:
+            res = self._fix_one(t)
+            detail = {
+                "title": t["title"],
+                "dir": t["dir"],
+                "ok": res.get("ok", False),
+                "source": res.get("source"),
+            }
+            if res.get("ok"):
+                summary["fixed"] += 1
+                if self._plex.refresh_metadata(t["rating_key"]):
+                    summary["refreshed"] += 1
+            else:
+                summary["failed"] += 1
+                detail["error"] = res.get("error")
+                logger.warning(
+                    "缺 poster 修复失败 %s: %s", t["dir"], res.get("error")
+                )
+            summary["details"].append(detail)
+        return summary

--- a/plugins.v3/plextoolbox/proxy_app.py
+++ b/plugins.v3/plextoolbox/proxy_app.py
@@ -1,0 +1,1069 @@
+from asyncio import Lock, create_task, gather, get_event_loop, to_thread, wait_for
+from contextlib import asynccontextmanager
+from re import compile as re_compile
+from time import monotonic
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from urllib.parse import quote, urlparse
+
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import (
+    JSONResponse,
+    RedirectResponse,
+    Response,
+    StreamingResponse,
+)
+from httpx import (
+    AsyncClient,
+    Limits,
+)
+from starlette.requests import ClientDisconnect
+from websockets import connect
+
+from app.sdk.logging import logger
+
+# 直链解析结果缓存 TTL（秒）：缓存的是 STRM 内部地址/规则替换结果（稳定中间地址），可长缓存
+REDIRECT_URL_CACHE_TTL_SECONDS = 900
+# Part 路径缓存 TTL（秒）：来自元数据 API 的 Part.key -> file 映射
+PART_INFO_CACHE_TTL_SECONDS = 3600
+# 直链缓存最大条目数
+REDIRECT_URL_CACHE_MAX_SIZE = 500
+# Part 路径缓存最大条目数
+PART_INFO_CACHE_MAX_SIZE = 2000
+# 详情页预热：响应中 Part 数不超过该值时才触发 STRM 预热（避免整库列表触发风暴）
+PREWARM_MAX_PARTS = 5
+# 热路径（起播关键路径）上游请求超时（秒）：收敛以避免拖慢起播
+HOT_PATH_TIMEOUT_SECONDS = 5.0
+
+# 非关键路径前缀：上游连接失败时静默降级为 DEBUG 日志（客户端高频轮询，失败无碍）
+SILENT_FAIL_PATH_PREFIXES = (
+    "/photo/:/transcode",
+    "/hubs",
+    "/statistics",
+    "/updater",
+    "/media/providers",
+    "/:/prefs",
+)
+
+# 播前补全：同一 ratingKey 补全冷却时间（秒），避免反复播放同一条目重复写
+# 播前补全：同步等待补全完成的最长时间（秒），超时后放行播放、补全转后台继续
+PREPLAY_WAIT_BUDGET_SECONDS = 3.0
+# playQueues 请求 uri 参数中的条目 ratingKey 提取
+_PLAYQUEUE_KEY_RE = re_compile(r"(?:library%2Fmetadata%2F|library/metadata/)(\d+)")
+
+# Plex Token 的可能来源
+PLEX_TOKEN_QUERY_KEY = "X-Plex-Token"
+PLEX_TOKEN_HEADER_KEY = "x-plex-token"
+
+# 逐跳头，转发时剔除
+HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+# 需要拦截并缓存 Part 信息的元数据 API 路径前缀
+METADATA_PATH_PREFIXES = (
+    "/library/metadata/",
+    "/library/sections/",
+    "/hubs",
+    "/playQueues",
+    "/status/sessions",
+)
+
+
+def create_app(
+    plex_host: str,
+    plex_token: str = "",
+    pin_rules: List[Tuple[str, str]] | None = None,
+    force_direct_play: bool = True,
+    preplay_cooldown_seconds: int = 600,
+    on_pre_play: Optional[Callable[[str], Any]] = None,
+) -> FastAPI:
+    """
+    创建 Plex 302 反向代理 FastAPI 应用
+
+    :param plex_host (str): Plex 服务器根地址，如 http://192.168.1.100:32400
+    :param plex_token (str): 备用 X-Plex-Token；请求自带 token 时优先使用请求中的
+    :param pin_rules (List): 顶置路径规则列表 (路径前缀, 目标URL)；命中时先替换再 302
+    :param force_direct_play (bool): 是否在 decision 请求中强制 DirectPlay，避免转码使 302 失效
+    :param on_pre_play (Callable): 播前补全回调，参数为 ratingKey，同步阻塞执行；
+        在 playQueues 创建（含继续观看直接起播）时先补全该条目媒体流信息再放行
+
+    :return FastAPI: 配置好的 FastAPI 应用实例
+    """
+    plex_host = plex_host.rstrip("/")
+    pin_rules = pin_rules or []
+
+    def _extract_token(request: Request) -> str:
+        """
+        从请求中提取 X-Plex-Token，优先级：查询参数 → 请求头 → 插件配置兜底
+
+        :param request: 当前请求
+        :return: token 字符串，可能为空串
+        """
+        token = request.query_params.get(PLEX_TOKEN_QUERY_KEY)
+        if token:
+            return token
+        token = request.headers.get(PLEX_TOKEN_HEADER_KEY)
+        if token:
+            return token
+        return plex_token or ""
+
+    def _build_forward_headers(request: Request) -> Dict[str, str]:
+        """
+        构建转发请求头，排除 host 和逐跳头
+
+        :param request: 当前请求
+        :return: 用于转发的请求头字典
+        """
+        return {
+            k: v
+            for k, v in request.headers.items()
+            if k.lower() not in HOP_BY_HOP_HEADERS and k.lower() != "host"
+        }
+
+    def _strip_accept_encoding(headers: Dict[str, str]) -> Dict[str, str]:
+        """
+        去掉 Accept-Encoding，便于上游返回未压缩内容以便修改 body
+
+        :param headers: 原始转发头
+        :return: 不包含 accept-encoding 的头字典
+        """
+        return {k: v for k, v in headers.items() if k.lower() != "accept-encoding"}
+
+    def _apply_pin_rules(url_or_path: str, rules: List[Tuple[str, str]]) -> str:
+        """
+        对文件路径（本地路径或 URL）应用顶置规则：匹配前缀则替换为目标 URL
+
+        :param url_or_path: 完整 URL 或路径字符串
+        :param rules: 顶置规则列表 (路径前缀, 目标URL)
+        :return: 替换后的 URL，未命中则返回原串
+        """
+        if not url_or_path or not rules:
+            return url_or_path
+        path_component: str
+        original_query: str = ""
+        if url_or_path.startswith(("http://", "https://")):
+            parsed = urlparse(url_or_path)
+            path_component = parsed.path or "/"
+            original_query = parsed.query or ""
+        else:
+            path_component = (
+                url_or_path if url_or_path.startswith("/") else "/" + url_or_path
+            )
+        for path_prefix, target_url in rules:
+            if path_component != path_prefix and not path_component.startswith(
+                path_prefix + "/"
+            ):
+                continue
+            suffix = path_component[len(path_prefix):].lstrip("/")
+            base = target_url.rstrip("/")
+            new_url = base + ("/" + quote(suffix, safe="/") if suffix else "")
+            if original_query:
+                new_url += "?" + original_query
+            return new_url
+        return url_or_path
+
+    def _is_http_media_path(path: str) -> bool:
+        """
+        判断文件路径是否为可 302 的远程地址（STRM 内容或规则替换结果）
+
+        :param path: 文件路径或 URL
+        :return: 是 HTTP/HTTPS 地址时为 True
+        """
+        return isinstance(path, str) and path.startswith(("http://", "https://"))
+
+    async def _read_request_body_safe(request: Request) -> bytes | None:
+        """
+        读取请求体；客户端已断开时返回 None，避免 ClientDisconnect 导致 500
+
+        :param request: 当前请求
+        :return: 请求体字节串，或 None 表示客户端已断开
+        """
+        try:
+            return await request.body()
+        except ClientDisconnect:
+            logger.debug(
+                "客户端已断开: %s %s",
+                request.method,
+                request.scope.get("path", ""),
+            )
+            return None
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        """
+        FastAPI 生命周期管理器：创建共享 httpx 客户端及缓存，关闭时清理资源
+        """
+        limits = Limits(max_keepalive_connections=50, keepalive_expiry=60.0)
+        app.state.http_client_follow = AsyncClient(follow_redirects=True, limits=limits)
+        app.state.http_client_no_follow = AsyncClient(
+            follow_redirects=False, limits=limits
+        )
+        # part_key(如 /library/parts/1/2/file) -> (file_path, expiry)
+        app.state.part_info_cache = {}
+        app.state.part_rating_cache = {}
+        # part_path -> (strm_content_url, expiry)
+        app.state.strm_content_cache = {}
+        app.state.part_info_lock = Lock()
+        # (part_key, header_hash) -> (final_url, expiry)
+        app.state.redirect_url_cache = {}
+        app.state.redirect_cache_order = []
+        app.state.redirect_cache_lock = Lock()
+        # 单飞合并：part_path -> Future[str]，并发相同请求共享一次解析
+        app.state.inflight_redirects = {}
+        app.state.inflight_lock = Lock()
+        yield
+        await app.state.http_client_follow.aclose()
+        await app.state.http_client_no_follow.aclose()
+
+    app = FastAPI(lifespan=lifespan)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # ---------- Part 路径缓存 ----------
+
+    async def _cache_part_info(
+        request: Request, part_key: str, file_path: str, rating_key: str = ""
+    ) -> None:
+        """
+        缓存 Part.key -> 文件路径映射，供后续播放请求直接使用
+
+        :param request: 当前请求
+        :param part_key: Part 的 key，如 /library/parts/123/456/file
+        :param file_path: 媒体文件的真实路径
+        """
+        if not part_key or not file_path:
+            return
+        cache = request.app.state.part_info_cache
+        async with request.app.state.part_info_lock:
+            if len(cache) >= PART_INFO_CACHE_MAX_SIZE:
+                now = monotonic()
+                expired = [k for k, v in cache.items() if v[1] < now]
+                for k in expired:
+                    cache.pop(k, None)
+                while len(cache) >= PART_INFO_CACHE_MAX_SIZE:
+                    cache.pop(next(iter(cache)), None)
+            # part_key 可能带查询参数，只取 path 部分
+            key = part_key.split("?", 1)[0]
+            cache[key] = (file_path, monotonic() + PART_INFO_CACHE_TTL_SECONDS)
+            if rating_key:
+                request.app.state.part_rating_cache[key] = (
+                    str(rating_key), monotonic() + PART_INFO_CACHE_TTL_SECONDS
+                )
+
+    async def _get_cached_part_path(request: Request, part_key: str) -> str:
+        """
+        查询 Part 路径缓存
+
+        :param request: 当前请求
+        :param part_key: Part 的 key（请求路径）
+        :return: 命中的文件路径，未命中返回空串
+        """
+        cache = request.app.state.part_info_cache
+        async with request.app.state.part_info_lock:
+            entry = cache.get(part_key)
+            if not entry:
+                return ""
+            file_path, expiry = entry
+            if monotonic() >= expiry:
+                cache.pop(part_key, None)
+                return ""
+            return file_path
+
+    async def _get_cached_part_rating_key(request: Request, part_key: str) -> str:
+        """读取 Part 对应的条目 ratingKey，供直接文件起播时补全兜底。"""
+        cache = request.app.state.part_rating_cache
+        async with request.app.state.part_info_lock:
+            entry = cache.get(part_key)
+            if not entry:
+                return ""
+            rating_key, expiry = entry
+            if monotonic() >= expiry:
+                cache.pop(part_key, None)
+                return ""
+            return str(rating_key)
+
+    def _extract_parts_from_json(data: Any) -> List[Tuple[str, str, str]]:
+        """
+        从 Plex JSON 响应的 MediaContainer 中抽取所有 Part 的 (key, file) 对
+
+        :param data: Plex API JSON 响应
+        :return: (part_key, file_path) 列表
+        """
+        result: List[Tuple[str, str, str]] = []
+        if not isinstance(data, dict):
+            return result
+        container = data.get("MediaContainer")
+        if not isinstance(container, dict):
+            return result
+        metadata_arr: List[dict] = []
+        hubs = container.get("Hub")
+        if isinstance(hubs, list):
+            for hub in hubs:
+                if isinstance(hub, dict) and isinstance(hub.get("Metadata"), list):
+                    metadata_arr.extend(
+                        m for m in hub["Metadata"] if isinstance(m, dict)
+                    )
+        if isinstance(container.get("Metadata"), list):
+            metadata_arr.extend(
+                m for m in container["Metadata"] if isinstance(m, dict)
+            )
+        for metadata in metadata_arr:
+            rating_key = str(metadata.get("ratingKey") or "")
+            media_list = metadata.get("Media")
+            if not isinstance(media_list, list):
+                continue
+            for media in media_list:
+                if not isinstance(media, dict):
+                    continue
+                parts = media.get("Part")
+                if not isinstance(parts, list):
+                    continue
+                for part in parts:
+                    if not isinstance(part, dict):
+                        continue
+                    key = part.get("key")
+                    file_path = part.get("file")
+                    if isinstance(key, str) and isinstance(file_path, str):
+                        result.append((key, file_path, rating_key))
+        return result
+
+    def _extract_parts_from_xml(text: str) -> List[Tuple[str, str, str]]:
+        """
+        从 Plex XML 响应中抽取所有 Part 的 (key, file) 对
+
+        :param text: XML 文本
+        :return: (part_key, file_path) 列表
+        """
+        from xml.etree import ElementTree
+
+        result: List[Tuple[str, str, str]] = []
+        try:
+            root = ElementTree.fromstring(text)
+        except ElementTree.ParseError:
+            return result
+        for metadata in root.iter():
+            rating_key = metadata.get("ratingKey") or ""
+            if not rating_key:
+                continue
+            for part in metadata.iter("Part"):
+                key = part.get("key")
+                file_path = part.get("file")
+                if key and file_path:
+                    result.append((key, file_path, str(rating_key)))
+        return result
+
+    async def _harvest_parts_from_response(
+        request: Request, content_type: str, body: bytes
+    ) -> int:
+        """
+        从元数据类响应中解析并缓存所有 Part 信息
+
+        :param request: 当前请求
+        :param content_type: 响应 Content-Type
+        :param body: 响应体字节串
+        :return: 缓存的 Part 数量
+        """
+        pairs: List[Tuple[str, str, str]] = []
+        try:
+            if "application/json" in content_type:
+                from json import loads
+
+                pairs = _extract_parts_from_json(loads(body))
+            elif "xml" in content_type:
+                pairs = _extract_parts_from_xml(body.decode("utf-8", errors="replace"))
+        except Exception:
+            logger.debug("解析元数据响应失败，跳过 Part 缓存", exc_info=True)
+            return 0
+        for key, file_path, rating_key in pairs:
+            await _cache_part_info(request, key, file_path, rating_key)
+        # 单集详情页（Part 数少）时后台预热 STRM 解析，正式播放可直接命中缓存
+        if 0 < len(pairs) <= PREWARM_MAX_PARTS:
+            for key, file_path, _rating_key in pairs:
+                if file_path.lower().endswith(".strm"):
+                    create_task(
+                        _prewarm_strm(request, key.split("?", 1)[0])
+                    )
+        return len(pairs)
+
+    async def _prewarm_strm(request: Request, part_path: str) -> None:
+        """
+        后台预热：提前解析 STRM 内容并写入缓存，失败静默
+
+        :param request: 触发预热的元数据请求（借用其 token 与共享客户端）
+        :param part_path: Part 的 key 路径
+        """
+        try:
+            url = await _resolve_strm_content(request, part_path)
+            if url:
+                logger.debug("STRM 预热完成: %s", part_path)
+        except Exception:
+            logger.debug("STRM 预热失败: %s", part_path, exc_info=True)
+
+    # ---------- Plex API 查询 ----------
+
+    async def _fetch_plex_file_path(request: Request, part_path: str) -> str:
+        """
+        通过 Plex API 查询播放路径对应媒体文件的真实路径
+
+        先查 Part 缓存；未命中时回退调用 /library/parts 对应的 metadata 无法直接反查，
+        改为向 Plex 发起带 Accept: application/json 的条目查询
+
+        :param request: 当前请求
+        :param part_path: 播放请求路径，如 /library/parts/123/456/file
+        :return: 文件真实路径，失败返回空串
+        """
+        cached = await _get_cached_part_path(request, part_path)
+        if cached:
+            logger.debug("Part 路径缓存命中: %s", part_path)
+            return cached
+        token = _extract_token(request)
+        if not token:
+            logger.warning("无 X-Plex-Token，无法查询 Plex API: %s", part_path)
+            return ""
+        # /library/parts/{part_id}/{ts}/file 无法直接反查条目，
+        # 使用 HEAD download 请求获取重定向或文件名后再搜索的方式成本高，
+        # 这里通过 Plex 的 parts 端点尝试直接查询
+        client = request.app.state.http_client_follow
+        # 从路径中提取 part_id
+        segments = [s for s in part_path.split("/") if s]
+        part_id = ""
+        if len(segments) >= 3 and segments[0] == "library" and segments[1] == "parts":
+            part_id = segments[2]
+        if not part_id:
+            return ""
+        url = f"{plex_host}/library/parts/{part_id}?X-Plex-Token={quote(token, safe='')}"
+        try:
+            resp = await client.get(
+                url,
+                headers={"Accept": "application/json"},
+                timeout=HOT_PATH_TIMEOUT_SECONDS,
+            )
+            if resp.status_code == 200:
+                pairs = _extract_parts_from_json(resp.json())
+                for key, file_path, rating_key in pairs:
+                    await _cache_part_info(request, key, file_path, rating_key)
+                    if key.split("?", 1)[0] == part_path:
+                        return file_path
+                if pairs:
+                    return pairs[0][1]
+        except Exception:
+            logger.debug("Plex parts API 查询失败: %s", url, exc_info=True)
+        return ""
+
+    async def _resolve_strm_content(request: Request, part_path: str) -> str:
+        """
+        通过 Plex download 接口 HEAD 请求解析 STRM 文件内容指向的远程地址
+
+        Plex 对 .strm 的 download 请求会返回 30x Location 指向文件内实际地址；
+        解析结果按 part_path 缓存，跨客户端复用
+
+        :param request: 当前请求
+        :param part_path: 播放请求路径
+        :return: STRM 指向的远程 URL，失败返回空串
+        """
+        strm_cache = request.app.state.strm_content_cache
+        entry = strm_cache.get(part_path)
+        if entry:
+            content, expiry = entry
+            if monotonic() < expiry:
+                logger.debug("STRM 内容缓存命中: %s", part_path)
+                return content
+            strm_cache.pop(part_path, None)
+        token = _extract_token(request)
+        if not token:
+            return ""
+        url = f"{plex_host}{part_path}?download=1&X-Plex-Token={quote(token, safe='')}"
+        client = request.app.state.http_client_no_follow
+        try:
+            resp = await client.head(url, timeout=HOT_PATH_TIMEOUT_SECONDS)
+            if 300 < resp.status_code < 309:
+                location = resp.headers.get("location", "")
+                if location and not location.startswith(plex_host):
+                    if len(strm_cache) >= PART_INFO_CACHE_MAX_SIZE:
+                        now = monotonic()
+                        for k in [
+                            k for k, v in strm_cache.items() if v[1] < now
+                        ]:
+                            strm_cache.pop(k, None)
+                        while len(strm_cache) >= PART_INFO_CACHE_MAX_SIZE:
+                            strm_cache.pop(next(iter(strm_cache)), None)
+                    strm_cache[part_path] = (
+                        location,
+                        monotonic() + PART_INFO_CACHE_TTL_SECONDS,
+                    )
+                    return location
+        except Exception:
+            logger.debug("STRM 内容解析失败: %s", part_path, exc_info=True)
+        return ""
+
+    # ---------- 302 重定向核心 ----------
+
+    async def _try_redirect(request: Request) -> RedirectResponse | None:
+        """
+        尝试对播放/下载请求返回 302 直链重定向
+
+        优先级：直链缓存 → 单飞合并解析（Part 文件路径 → 顶置规则/STRM）
+
+        并发相同 part 的请求（客户端起播常见的重试/多连接）通过单飞合并，
+        只触发一次上游解析，其余请求等待同一结果，避免起播被重复解析拖慢。
+
+        :param request: 当前请求
+        :return: 302 重定向响应，或 None 表示回退到反向代理
+        """
+        part_path = request.scope.get("path", "")
+
+        # 缓存的是稳定中间地址（与客户端无关），仅按路径缓存以提高跨客户端命中率
+        cache_key = part_path
+        cache = request.app.state.redirect_url_cache
+        order = request.app.state.redirect_cache_order
+        lock = request.app.state.redirect_cache_lock
+
+        async with lock:
+            entry = cache.get(cache_key)
+            if entry:
+                final_url, expiry = entry
+                if monotonic() < expiry:
+                    logger.debug("直链缓存命中: %s", part_path)
+                    return RedirectResponse(url=final_url, status_code=302)
+                cache.pop(cache_key, None)
+                try:
+                    order.remove(cache_key)
+                except ValueError:
+                    pass
+
+        # 单飞合并：相同 part_path 的并发解析只执行一次
+        inflight = request.app.state.inflight_redirects
+        inflight_lock = request.app.state.inflight_lock
+        owner = False
+        async with inflight_lock:
+            fut = inflight.get(part_path)
+            if fut is None:
+                fut = get_event_loop().create_future()
+                inflight[part_path] = fut
+                owner = True
+
+        if not owner:
+            logger.debug("等待单飞解析: %s", part_path)
+            http_url = await fut
+        else:
+            try:
+                http_url = await _resolve_redirect_url(request, part_path)
+            except Exception:
+                logger.debug("解析直链异常: %s", part_path, exc_info=True)
+                http_url = ""
+            finally:
+                async with inflight_lock:
+                    inflight.pop(part_path, None)
+                if not fut.done():
+                    fut.set_result(http_url)
+
+        if not http_url:
+            return None
+
+        # 直接 302 到中间地址（STRM 内部 redirect_url 或规则替换结果），
+        # 由客户端自行跟随后续跳转，避免服务端预解析引入延迟
+        final_url = http_url
+
+        async with lock:
+            now = monotonic()
+            expired = [k for k in order if cache.get(k) and cache[k][1] < now]
+            for k in expired:
+                cache.pop(k, None)
+            order[:] = [k for k in order if k not in frozenset(expired)]
+            while len(cache) >= REDIRECT_URL_CACHE_MAX_SIZE and order:
+                cache.pop(order.pop(0), None)
+            cache[cache_key] = (final_url, now + REDIRECT_URL_CACHE_TTL_SECONDS)
+            order.append(cache_key)
+
+        logger.info("302 重定向: %s -> %s", part_path, final_url)
+        return RedirectResponse(url=final_url, status_code=302)
+
+    async def _resolve_redirect_url(request: Request, part_path: str) -> str:
+        """
+        解析播放请求对应的可 302 远程地址（不含缓存/单飞逻辑）
+
+        :param request: 当前请求
+        :param part_path: 播放请求路径
+        :return: 可 302 的 HTTP(S) 地址，无法解析返回空串
+        """
+        file_path = await _fetch_plex_file_path(request, part_path)
+        http_url = ""
+        if file_path:
+            replaced = _apply_pin_rules(file_path, pin_rules)
+            if _is_http_media_path(replaced):
+                http_url = replaced
+            elif file_path.lower().endswith(".strm"):
+                strm_url = await _resolve_strm_content(request, part_path)
+                if strm_url:
+                    strm_replaced = _apply_pin_rules(strm_url, pin_rules)
+                    http_url = (
+                        strm_replaced
+                        if _is_http_media_path(strm_replaced)
+                        else strm_url
+                    )
+        else:
+            # 无法拿到文件路径时，仍尝试 STRM 解析（Plex 会自己 30x）
+            strm_url = await _resolve_strm_content(request, part_path)
+            if strm_url:
+                strm_replaced = _apply_pin_rules(strm_url, pin_rules)
+                if _is_http_media_path(strm_replaced):
+                    http_url = strm_replaced
+        return http_url
+
+    async def _handle_stream(request: Request, part_id: str, file_id: str = ""):
+        """
+        处理播放/下载流路由：尝试 302，失败则走通用反向代理
+
+        :param request: 当前请求
+        :param part_id: Part ID
+        :param file_id: 文件时间戳段（由路由匹配）
+        :return: 重定向或反代响应
+        """
+        logger.info("播放请求: %s", request.scope.get("path", ""))
+        part_path = request.scope.get("path", "")
+        rating_key = await _get_cached_part_rating_key(request, part_path)
+        if not rating_key:
+            await _fetch_plex_file_path(request, part_path)
+            rating_key = await _get_cached_part_rating_key(request, part_path)
+        if rating_key:
+            await _maybe_pre_play_complete(rating_key)
+        resp = await _try_redirect(request)
+        if resp:
+            return resp
+        logger.info("302 未命中，回退反代: %s", request.scope.get("path", ""))
+        return await _reverse_proxy(request)
+
+    for _route in (
+        "/library/parts/{part_id}/{file_id}/file",
+        "/library/parts/{part_id}/file",
+    ):
+        app.api_route(_route, methods=["GET", "HEAD"], response_model=None)(
+            _handle_stream
+        )
+
+    # ---------- 转码决策：强制 DirectPlay ----------
+
+    async def _handle_transcode_decision(request: Request):
+        """
+        代理 /video/:/transcode/universal/decision：
+        当媒体文件为远程直链（STRM/规则命中）时强制 DirectPlay，
+        避免 Plex 走转码使 302 直链失效
+
+        :param request: 当前请求
+        :return: 透传或改参后的响应
+        """
+        if not force_direct_play:
+            return await _reverse_proxy(request)
+        logger.info("转码决策请求: %s", str(request.url.query)[:200])
+        # 改写查询参数强制直接播放
+        query = dict(request.query_params)
+        query["directPlay"] = "1"
+        query["directStream"] = "1"
+        path = request.scope.get("path", "/")
+        qs = "&".join(f"{quote(k, safe='')}={quote(str(v), safe='')}" for k, v in query.items())
+        target_url = f"{plex_host}{path}?{qs}"
+        headers = _build_forward_headers(request)
+        client = request.app.state.http_client_no_follow
+        try:
+            resp = await client.request(
+                request.method, target_url, headers=headers, timeout=30.0
+            )
+        except Exception:
+            logger.warning("转码决策请求失败: %s", target_url, exc_info=True)
+            return await _reverse_proxy(request)
+        excluded = HOP_BY_HOP_HEADERS | {"content-encoding", "content-length"}
+        resp_headers = {
+            k: v for k, v in resp.headers.multi_items() if k.lower() not in excluded
+        }
+        # 顺带缓存决策响应中的 Part 信息
+        ct = (resp.headers.get("content-type") or "").lower()
+        if resp.status_code == 200:
+            count = await _harvest_parts_from_response(request, ct, resp.content)
+            if count:
+                logger.debug("转码决策响应缓存 Part: %s 条", count)
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            headers=resp_headers,
+        )
+
+    app.api_route(
+        "/video/:/transcode/universal/decision",
+        methods=["GET", "HEAD"],
+        response_model=None,
+    )(_handle_transcode_decision)
+
+    # 转码播放起始请求也尝试 302（对应 plex2Alist 的 VideoTranscodePlay）
+    async def _handle_transcode_start(request: Request):
+        """
+        处理 /video/:/transcode/universal/start：
+        客户端明确要求转码(directPlay=0)时透传，否则尝试按 path 参数解析并 302
+
+        :param request: 当前请求
+        :return: 重定向或反代响应
+        """
+        if request.query_params.get("directPlay") == "0" and not force_direct_play:
+            return await _reverse_proxy(request)
+        logger.info(
+            "转码起始请求: %s path=%s",
+            request.scope.get("path", ""),
+            request.query_params.get("path", ""),
+        )
+        # start 请求带 path=/library/metadata/{id} 参数，查询条目拿文件路径
+        meta_path = request.query_params.get("path", "")
+        token = _extract_token(request)
+        if meta_path and token:
+            client = request.app.state.http_client_follow
+            url = f"{plex_host}{meta_path}?X-Plex-Token={quote(token, safe='')}"
+            try:
+                resp = await client.get(
+                    url, headers={"Accept": "application/json"}, timeout=10
+                )
+                if resp.status_code == 200:
+                    pairs = _extract_parts_from_json(resp.json())
+                    media_index = int(request.query_params.get("mediaIndex") or 0)
+                    part_index = int(request.query_params.get("partIndex") or 0)
+                    idx = media_index + part_index
+                    pair = (
+                        pairs[idx]
+                        if 0 <= idx < len(pairs)
+                        else (pairs[0] if pairs else None)
+                    )
+                    if pair:
+                        part_key, file_path, rating_key = pair
+                        await _cache_part_info(request, part_key, file_path, rating_key)
+                        http_url = ""
+                        replaced = _apply_pin_rules(file_path, pin_rules)
+                        if _is_http_media_path(replaced):
+                            http_url = replaced
+                        elif file_path.lower().endswith(".strm"):
+                            # STRM：通过 download 接口解析内部地址
+                            strm_url = await _resolve_strm_content(
+                                request, part_key.split("?", 1)[0]
+                            )
+                            if strm_url:
+                                strm_replaced = _apply_pin_rules(strm_url, pin_rules)
+                                http_url = (
+                                    strm_replaced
+                                    if _is_http_media_path(strm_replaced)
+                                    else strm_url
+                                )
+                        if http_url:
+                            logger.info(
+                                "302 重定向(转码起始): %s -> %s", meta_path, http_url
+                            )
+                            return RedirectResponse(url=http_url, status_code=302)
+            except Exception:
+                logger.debug("转码起始解析失败: %s", meta_path, exc_info=True)
+        logger.info("转码起始未命中 302，回退反代: %s", meta_path)
+        return await _reverse_proxy(request)
+
+    for _start_route in (
+        "/video/:/transcode/universal/start",
+        "/video/:/transcode/universal/start.mpd",
+        "/video/:/transcode/universal/start.m3u8",
+    ):
+        app.api_route(
+            _start_route,
+            methods=["GET", "HEAD"],
+            response_model=None,
+        )(_handle_transcode_start)
+
+    # ---------- 播前补全（继续观看点击即播场景） ----------
+
+    # ratingKey -> 上次播前补全的单调时间戳
+    _preplay_recent: Dict[str, float] = {}
+    _preplay_lock = Lock()
+
+    async def _maybe_pre_play_complete(rating_key: str) -> None:
+        """
+        播前补全：在放行播放请求前，同步等待补全该条目媒体流信息。
+
+        带冷却窗口去重；等待预算内没完成就放行播放，补全在后台线程继续，
+        绝不为写库阻塞起播超过 PREPLAY_WAIT_BUDGET_SECONDS。
+
+        :param rating_key: 即将播放条目的 ratingKey
+        """
+        if on_pre_play is None or not rating_key:
+            return
+        now = monotonic()
+        async with _preplay_lock:
+            last = _preplay_recent.get(rating_key)
+            if last is not None and now - last < preplay_cooldown_seconds:
+                return
+            _preplay_recent[rating_key] = now
+            # 顺带清理过期记录
+            expired = [
+                k for k, ts in _preplay_recent.items()
+                if now - ts > preplay_cooldown_seconds
+            ]
+            for k in expired:
+                if k != rating_key:
+                    _preplay_recent.pop(k, None)
+        try:
+            await wait_for(
+                to_thread(on_pre_play, rating_key),
+                timeout=PREPLAY_WAIT_BUDGET_SECONDS,
+            )
+            logger.info("播前补全完成: ratingKey=%s", rating_key)
+        except TimeoutError:
+            # to_thread 里的补全线程会继续跑完（写库仍生效），只是不再阻塞起播
+            logger.info(
+                "播前补全超过 %ss 预算，先放行播放（补全后台继续）: ratingKey=%s",
+                PREPLAY_WAIT_BUDGET_SECONDS, rating_key,
+            )
+        except Exception as exc:
+            logger.debug("播前补全异常 ratingKey=%s: %s", rating_key, exc)
+
+    def _extract_rating_key_from_playqueue(request: Request) -> str:
+        """
+        从 playQueues 创建请求中提取目标条目 ratingKey。
+
+        「继续观看」点击即播时，客户端会 POST /playQueues，
+        uri 参数形如 server://xxx/com.plexapp.plugins.library/library/metadata/123。
+
+        :param request: 当前请求
+        :return: ratingKey，取不到返回空串
+        """
+        try:
+            uri = request.query_params.get("uri") or ""
+            key = request.query_params.get("key") or ""
+            m = _PLAYQUEUE_KEY_RE.search(key) or _PLAYQUEUE_KEY_RE.search(uri)
+            return m.group(1) if m else ""
+        except Exception:
+            return ""
+
+    async def _playqueue_proxy(request: Request):
+        """
+        代理 playQueues 创建：先尝试播前补全目标条目媒体流信息，再转发。
+
+        覆盖「继续观看」点击即播（不经过详情页）的场景；补全带预算超时，
+        不会明显拖慢起播。
+
+        :param request: 当前请求
+        :return: 上游响应
+        """
+        if request.method == "POST":
+            rating_key = _extract_rating_key_from_playqueue(request)
+            if rating_key:
+                await _maybe_pre_play_complete(rating_key)
+        return await _metadata_proxy(request)
+
+    # ---------- 元数据 API：缓存 Part 信息 ----------
+
+    async def _metadata_proxy(request: Request):
+        """
+        代理元数据类 API，整包拉取响应并抽取缓存 Part.key -> file 映射
+
+        :param request: 当前请求
+        :return: 上游响应（原样透传）
+        """
+        path = request.scope.get("path", "/")
+        qs = str(request.url.query)
+        target_url = f"{plex_host}{path}"
+        if qs:
+            target_url += f"?{qs}"
+        headers = _strip_accept_encoding(_build_forward_headers(request))
+        body = await _read_request_body_safe(request)
+        if body is None:
+            return Response(status_code=204, content=b"")
+        client = request.app.state.http_client_no_follow
+        try:
+            resp = await client.request(
+                request.method,
+                target_url,
+                headers=headers,
+                content=body if body else None,
+                timeout=60.0,
+            )
+        except Exception:
+            logger.warning("元数据请求失败: %s", target_url, exc_info=True)
+            return JSONResponse(
+                status_code=502,
+                content={
+                    "error": "Bad Gateway",
+                    "detail": f"无法连接到 Plex 服务器: {plex_host}",
+                },
+            )
+        ct = (resp.headers.get("content-type") or "").lower()
+        if resp.status_code == 200 and request.method == "GET":
+            count = await _harvest_parts_from_response(request, ct, resp.content)
+            if count:
+                logger.debug("元数据响应缓存 Part: path=%s, %s 条", path, count)
+        excluded = HOP_BY_HOP_HEADERS | {"content-encoding", "content-length"}
+        resp_headers = {
+            k: v for k, v in resp.headers.multi_items() if k.lower() not in excluded
+        }
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            headers=resp_headers,
+        )
+
+    for _meta_route in (
+        "/library/metadata/{item_id}",
+        "/library/metadata/{item_id}/children",
+        "/library/sections/{section_id}/all",
+        "/playQueues/{queue_id}",
+        "/status/sessions",
+    ):
+        app.api_route(_meta_route, methods=["GET", "POST"], response_model=None)(
+            _metadata_proxy
+        )
+
+    # playQueues 创建单独走播前补全代理（继续观看点击即播场景）
+    app.api_route("/playQueues", methods=["GET", "POST"], response_model=None)(
+        _playqueue_proxy
+    )
+
+    # ---------- WebSocket 代理 ----------
+
+    async def _ws_proxy(ws_client: WebSocket) -> None:
+        """
+        双向代理客户端 WebSocket 与 Plex 后端 WebSocket
+
+        :param ws_client: 客户端 WebSocket 连接
+        """
+        await ws_client.accept()
+        parsed = urlparse(plex_host)
+        scheme = "wss" if parsed.scheme == "https" else "ws"
+        path = ws_client.scope.get("path", "/:/websockets/notifications")
+        qs = str(ws_client.scope.get("query_string", b""), "utf-8")
+        backend_url = f"{scheme}://{parsed.netloc}{path}"
+        if qs:
+            backend_url += f"?{qs}"
+        try:
+            async with connect(backend_url) as ws_backend:
+
+                async def client_to_backend() -> None:
+                    """
+                    WebSocket 客户端→后端：转发客户端文本消息到后端
+                    """
+                    try:
+                        while True:
+                            data = await ws_client.receive_text()
+                            await ws_backend.send(data)
+                    except WebSocketDisconnect:
+                        pass
+
+                async def backend_to_client() -> None:
+                    """
+                    WebSocket 后端→客户端：转发后端消息到客户端
+                    """
+                    try:
+                        async for msg in ws_backend:
+                            if isinstance(msg, str):
+                                await ws_client.send_text(msg)
+                            else:
+                                await ws_client.send_bytes(msg)
+                    except Exception as e:
+                        logger.debug("WebSocket 后端->客户端 结束: %s", e)
+
+                await gather(client_to_backend(), backend_to_client())
+        except Exception:
+            logger.warning("WebSocket 代理异常", exc_info=True)
+        finally:
+            try:
+                await ws_client.close()
+            except Exception as e:
+                logger.debug("关闭客户端 WebSocket 时异常: %s", e)
+
+    app.websocket("/:/websockets/notifications")(_ws_proxy)
+    app.websocket("/:/eventsource/notifications")(_ws_proxy)
+
+    # ---------- 通用反向代理与兜底 ----------
+
+    async def _reverse_proxy(request: Request):
+        """
+        将请求反向代理到 Plex 服务器并流式返回响应
+
+        :param request: 当前请求
+        :return: 流式响应或 502 JSON 错误
+        """
+        path = request.scope.get("path", "/")
+        qs = str(request.url.query)
+        target_url = f"{plex_host}{path}"
+        if qs:
+            target_url += f"?{qs}"
+        headers = _build_forward_headers(request)
+        body = await _read_request_body_safe(request)
+        if body is None:
+            return Response(status_code=204, content=b"")
+        client = request.app.state.http_client_no_follow
+        try:
+            req = client.build_request(
+                method=request.method,
+                url=target_url,
+                headers=headers,
+                content=body if body else None,
+            )
+            resp = await client.send(req, stream=True)
+        except Exception:
+            # 高频非关键路径（图片转码/推荐位等）失败降为 DEBUG，避免日志刷屏
+            if path.startswith(SILENT_FAIL_PATH_PREFIXES):
+                logger.debug("Plex 非关键路径请求失败: %s", path)
+            else:
+                logger.warning("无法连接到 Plex: %s", target_url)
+            return JSONResponse(
+                status_code=502,
+                content={
+                    "error": "Bad Gateway",
+                    "detail": f"无法连接到 Plex 服务器: {plex_host}",
+                },
+            )
+        excluded = HOP_BY_HOP_HEADERS | {"content-encoding"}
+        if resp.headers.get("content-encoding"):
+            excluded = excluded | {"content-length"}
+        resp_headers = {
+            k: v for k, v in resp.headers.multi_items() if k.lower() not in excluded
+        }
+
+        async def stream():
+            """
+            流式读取 httpx 响应并逐块输出，完成后关闭响应
+            """
+            try:
+                async for chunk in resp.aiter_bytes(chunk_size=65536):
+                    yield chunk
+            finally:
+                await resp.aclose()
+
+        return StreamingResponse(
+            stream(),
+            status_code=resp.status_code,
+            headers=resp_headers,
+        )
+
+    # ---------- 播放状态嗅探（方案A：timeline 停止触发补全） ----------
+
+    @app.api_route(
+        "/{path:path}",
+        methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+        response_model=None,
+    )
+    async def catch_all(request: Request):
+        """
+        兜底路由：将未匹配请求反向代理到 Plex
+
+        :param request (Request): 当前请求
+        :return Response: 流式响应或 502 JSON 错误
+        """
+        return await _reverse_proxy(request)
+
+    return app

--- a/plugins.v3/plextoolbox/scrape_tools.py
+++ b/plugins.v3/plextoolbox/scrape_tools.py
@@ -1,0 +1,221 @@
+"""目录匹配/刮削工具：Plex 一键 unmatch 重读 NFO、扫描缺封面并交给 MP 刮削。"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+from app.sdk.logging import logger
+
+from .plex_client import PlexClient
+
+
+# 视为“已刮削/已有封面”的元数据文件（大小写不敏感匹配后缀/文件名）
+COVER_FILE_NAMES = ("poster.jpg", "poster.png", "folder.jpg", "cover.jpg")
+NFO_SUFFIX = ".nfo"
+
+
+def _dir_has_metadata(dir_path: str) -> bool:
+    """
+    判断某目录是否已有封面或 NFO 元数据文件。
+
+    :param dir_path: 目录绝对路径
+    :return: 目录内含 poster/nfo 等元数据返回 True
+    """
+    try:
+        for name in os.listdir(dir_path):
+            low = name.lower()
+            if low in COVER_FILE_NAMES or low.endswith(NFO_SUFFIX):
+                return True
+            # 兼容 <名字>-poster.jpg 命名
+            if "poster" in low and low.endswith((".jpg", ".png")):
+                return True
+    except OSError as exc:
+        logger.debug("读取目录失败 %s: %s", dir_path, exc)
+    return False
+
+
+def _dir_only_strm(dir_path: str) -> bool:
+    """
+    判断某目录（含子目录）是否只有 .strm 视频而无任何元数据文件。
+
+    仅检查该目录及其一层子目录（季目录）内是否存在 poster/nfo。
+
+    :param dir_path: 剧集/电影目录绝对路径
+    :return: 只有 strm 无元数据返回 True
+    """
+    if _dir_has_metadata(dir_path):
+        return False
+    try:
+        for name in os.listdir(dir_path):
+            sub = os.path.join(dir_path, name)
+            if os.path.isdir(sub) and _dir_has_metadata(sub):
+                return False
+    except OSError as exc:
+        logger.debug("读取目录失败 %s: %s", dir_path, exc)
+    return True
+
+
+class ScrapeTools:
+    """封装 Plex 一键取消匹配与缺封面刮削的编排逻辑。"""
+
+    def __init__(self, plex: PlexClient) -> None:
+        """
+        初始化。
+
+        :param plex: Plex 客户端
+        """
+        self._plex = plex
+
+    def unmatch_section(
+        self,
+        section_key: str,
+        dry_run: bool = True,
+        rematch: bool = True,
+        limit: int = 0,
+    ) -> Dict[str, Any]:
+        """
+        对指定分区一键取消匹配，让条目按当前 NFO 代理重读。
+
+        :param section_key: Plex 分区 key
+        :param dry_run: 为 True 时仅统计将影响的条目数，不执行
+        :param rematch: 取消匹配后是否触发刷新以重读 NFO
+        :param limit: 最多处理条目数，0 表示不限制
+        :return: 汇总结果
+        """
+        items = self._plex.iter_top_items(section_key)
+        summary: Dict[str, Any] = {
+            "section": section_key,
+            "dry_run": dry_run,
+            "rematch": rematch,
+            "total_items": len(items),
+            "unmatched": 0,
+            "refreshed": 0,
+            "failed": 0,
+        }
+        if dry_run:
+            summary["will_affect"] = len(items) if not limit else min(limit, len(items))
+            return summary
+        count = 0
+        for it in items:
+            if limit and count >= limit:
+                break
+            rk = it["rating_key"]
+            if self._plex.unmatch(rk):
+                summary["unmatched"] += 1
+                if rematch and self._plex.refresh_metadata(rk):
+                    summary["refreshed"] += 1
+            else:
+                summary["failed"] += 1
+            count += 1
+        return summary
+
+    def scan_missing_cover(
+        self,
+        section_key: str,
+        strm_roots: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        扫描分区内缺封面的条目：Plex 无 thumb 或 STRM 目录只有 strm。
+
+        :param section_key: Plex 分区 key
+        :param strm_roots: STRM 根目录列表（用于判断目录是否只有 strm），可为空
+        :return: {missing: [{rating_key, title, dir, reason}], total, checked}
+        """
+        items = self._plex.iter_top_items(section_key)
+        itype = self._plex.section_type(section_key)
+        missing: List[Dict[str, Any]] = []
+        for it in items:
+            rk = it["rating_key"]
+            reason = ""
+            if not it.get("has_thumb"):
+                reason = "plex_no_thumb"
+            file_path = self._plex.first_file_path(rk, itype)
+            media_dir = ""
+            if file_path:
+                # STRM 剧集下钻到集，取剧目录（file 的上两级）；电影取上一级
+                if itype == "show":
+                    media_dir = os.path.dirname(os.path.dirname(file_path))
+                else:
+                    media_dir = os.path.dirname(file_path)
+                if os.path.isdir(media_dir) and _dir_only_strm(media_dir):
+                    reason = reason or "dir_only_strm"
+            if reason:
+                missing.append(
+                    {
+                        "rating_key": rk,
+                        "title": it.get("title"),
+                        "dir": media_dir,
+                        "reason": reason,
+                    }
+                )
+        return {
+            "section": section_key,
+            "type": itype,
+            "checked": len(items),
+            "total": len(missing),
+            "missing": missing,
+        }
+
+    def scrape_missing(
+        self,
+        section_key: str,
+        scrape_cb: Callable[[str], Dict[str, Any]],
+        strm_roots: Optional[List[str]] = None,
+        dry_run: bool = True,
+        limit: int = 0,
+        unmatch_after: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        对缺封面条目调用 MP 刮削回调，可选刮削后 unmatch 让 Plex 重读。
+
+        :param section_key: Plex 分区 key
+        :param scrape_cb: 刮削回调，入参为目录路径，返回结果字典
+        :param strm_roots: STRM 根目录列表
+        :param dry_run: 为 True 时仅列出将刮削的目录，不执行
+        :param limit: 最多处理条目数，0 表示不限制
+        :param unmatch_after: 刮削后是否 unmatch+refresh 让 Plex 重读
+        :return: 汇总结果
+        """
+        scan = self.scan_missing_cover(section_key, strm_roots)
+        targets = [m for m in scan["missing"] if m.get("dir")]
+        summary: Dict[str, Any] = {
+            "section": section_key,
+            "dry_run": dry_run,
+            "candidates": len(targets),
+            "scraped": 0,
+            "unmatched": 0,
+            "refreshed": 0,
+            "failed": 0,
+            "details": [],
+        }
+        if dry_run:
+            summary["targets"] = [
+                {"title": t["title"], "dir": t["dir"], "reason": t["reason"]}
+                for t in (targets[:limit] if limit else targets)
+            ]
+            return summary
+        count = 0
+        for t in targets:
+            if limit and count >= limit:
+                break
+            d = t["dir"]
+            try:
+                res = scrape_cb(d)
+                ok = bool(res.get("success", True))
+                if ok:
+                    summary["scraped"] += 1
+                    if unmatch_after and self._plex.unmatch(t["rating_key"]):
+                        summary["unmatched"] += 1
+                    # 刮削成功后始终刷新条目，让 Plex 重读新生成的 NFO/图片
+                    if self._plex.refresh_metadata(t["rating_key"]):
+                        summary["refreshed"] += 1
+                else:
+                    summary["failed"] += 1
+                summary["details"].append({"dir": d, "ok": ok})
+            except Exception as exc:
+                summary["failed"] += 1
+                logger.error("刮削目录失败 %s: %s", d, exc, exc_info=True)
+                summary["details"].append({"dir": d, "ok": False, "error": str(exc)})
+            count += 1
+        return summary

--- a/plugins.v3/plextoolbox/src/components/Config.vue
+++ b/plugins.v3/plextoolbox/src/components/Config.vue
@@ -1,0 +1,281 @@
+<template>
+  <div class="ptb-config">
+    <VCard flat class="ptb-card">
+      <VCardItem class="ptb-header">
+        <template #prepend>
+          <VAvatar color="primary" variant="tonal" size="44" rounded="lg"><VIcon icon="mdi-plex" size="24" /></VAvatar>
+        </template>
+        <VCardTitle class="text-h6 ptb-header-title">PLEX 工具箱</VCardTitle>
+        <VCardSubtitle class="text-caption ptb-header-subtitle">{{ currentTab.desc }}</VCardSubtitle>
+        <template #append>
+          <div class="d-flex align-center ga-2">
+            <div v-if="changedCount" class="ptb-dirty-hint"><VIcon icon="mdi-circle-medium" color="warning" size="18" /><span class="text-caption text-warning">{{ changedCount }} 项待保存</span></div>
+            <VBtn v-if="changedCount" color="primary" variant="flat" size="small" prepend-icon="mdi-content-save" rounded="lg" :loading="saving" @click="saveConfig">保存修改</VBtn>
+            <VBtn icon="mdi-close" variant="text" size="small" @click="emit('close')" />
+          </div>
+        </template>
+      </VCardItem>
+      <VDivider />
+
+      <div class="ptb-body">
+        <nav class="ptb-nav">
+          <VList density="comfortable" nav class="py-2">
+            <VListItem v-for="item in tabs" :key="item.key" :active="activeTab === item.key" color="primary" rounded="lg" class="ptb-nav-item" @click="activeTab = item.key">
+              <template #prepend><VIcon :icon="item.icon" /></template>
+              <VListItemTitle>{{ item.title }}</VListItemTitle>
+              <template v-if="item.key === 'records' && history.length" #append><VChip size="x-small" variant="tonal">{{ history.length }}</VChip></template>
+            </VListItem>
+          </VList>
+        </nav>
+
+        <section class="ptb-content">
+          <div class="ptb-mobile-tabbar">
+            <div class="ptb-mobile-tabinfo"><div class="font-weight-medium">{{ currentTab.title }}</div><div class="text-caption text-medium-emphasis">{{ currentTab.desc }}</div></div>
+            <VBtn icon="mdi-menu-down" variant="tonal" size="small" @click="mobileTabSheet = true" />
+          </div>
+
+          <VAlert v-if="error" type="error" variant="tonal" density="compact" class="ptb-error-alert ma-3 mb-0 text-caption" closable @click:close="error = ''">{{ error }}</VAlert>
+
+          <div class="ptb-workspace">
+            <div class="ptb-window">
+              <div v-show="activeTab === 'proxy'" class="ptb-pane">
+                <div class="ptb-section-title">302 反向代理</div>
+                <VRow>
+                  <VCol cols="12"><VSwitch v-model="config.proxy_enabled" color="primary" hide-details inset label="启用 302 反向代理" /></VCol>
+                  <VCol cols="12" md="8"><VTextField v-model="config.plex_host" label="Plex 服务器地址" placeholder="http://192.168.0.122:32400" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="4"><VTextField v-model="config.plex_token" label="X-Plex-Token" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="6"><VTextField v-model="config.host" label="代理监听地址" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="6"><VTextField v-model.number="config.port" type="number" label="代理监听端口" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12"><VSwitch v-model="config.force_direct_play" color="primary" hide-details inset label="强制 DirectPlay（避免转码使直链失效）" /></VCol>
+                  <VCol cols="12"><VTextarea v-model="config.pin_rules" label="顶置路径规则（每行：路径前缀 => 目标URL）" variant="outlined" density="compact" rows="3" hide-details="auto" /></VCol>
+                </VRow>
+              </div>
+
+              <div v-show="activeTab === 'mediainfo'" class="ptb-pane">
+                <div class="ptb-section-title">STRM 媒体流信息补全</div>
+                <VAlert type="info" variant="tonal" density="compact" class="mb-3 text-caption">点击播放时先补全当前条目及设置的后续集，最多等待 3 秒后自动放行播放。需先在 Plex 主机部署 helper 写库服务；没有 Emby 时可直接用 ffprobe 探测 STRM 内的 302 直链。<a :href="helperDocUrl" target="_blank" rel="noopener" class="ptb-doc-link">查看部署说明</a></VAlert>
+                <VRow>
+                  <VCol cols="12"><VSwitch v-model="config.mediainfo_enabled" color="primary" hide-details inset label="启用媒体信息补全" /></VCol>
+                  <VCol cols="12" md="8"><VTextField v-model="config.plex_direct_host" label="Plex 直连地址（写库/枚举用）" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="4"><VBtn color="info" variant="tonal" size="small" :loading="checking" prepend-icon="mdi-lan-connect" @click="checkHelper">检查 helper</VBtn></VCol>
+                  <VCol cols="12" md="8"><VTextField v-model="config.helper_url" label="helper 地址" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="4"><VTextField v-model="config.helper_token" label="helper Token" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="6"><VSwitch v-model="config.use_emby" color="primary" hide-details inset label="数据源 Emby MediaStreams" /></VCol>
+                  <VCol cols="12" md="8"><VTextField v-model="config.emby_url" label="Emby 地址" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="4"><VTextField v-model="config.emby_apikey" label="Emby API Key" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12"><VSwitch v-model="config.use_ffprobe" color="primary" hide-details inset label="启用 ffprobe（无 Emby 或 Emby 未命中时读取 STRM 302 直链）" /></VCol>
+                  <VCol cols="12" md="8"><VTextField v-model="config.ffprobe_path_map" label="Plex 路径 → MoviePilot 容器路径映射" placeholder="/Volumes/data=/media" hint="每行一条，支持 =、=> 或分号分隔；Plex 主机路径在左，MP 容器路径在右" persistent-hint variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="4"><VTextField v-model.number="config.ffprobe_timeout" type="number" min="1" max="300" label="ffprobe 超时（秒）" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="8"><VSelect v-model="selectedSections" :items="sectionOptions" item-title="title" item-value="value" label="要补全的 Plex 媒体库" variant="outlined" density="compact" multiple chips closable-chips hide-details="auto" :loading="loadingSections"><template #append-inner><VBtn icon="mdi-refresh" size="x-small" variant="text" @click.stop="loadSections" /></template></VSelect></VCol>
+                  <VCol cols="12" md="4"><VTextField v-model.number="config.concurrency" type="number" min="1" max="10" label="探测并发数" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="6"><VSwitch v-model="config.only_missing" color="primary" hide-details inset label="仅处理缺失媒体信息的条目" /></VCol>
+                  <VCol cols="12" md="6"><VSwitch v-model="config.overwrite_streams" color="primary" hide-details inset label="写入前清空旧流" /></VCol>
+                  <VCol cols="12" md="6"><VSwitch v-model="config.webhook_enabled" color="primary" hide-details inset label="启用 Plex Webhook 触发" /></VCol>
+                  <VCol cols="12" md="6"><VTextField v-model.number="config.dedup_window" type="number" min="0" label="播前同条目去重窗口（秒）" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                  <VCol cols="12" md="6"><VTextField v-model.number="config.forward_episodes" type="number" min="0" label="剧集向后预取集数" variant="outlined" density="compact" hide-details="auto" /></VCol>
+                </VRow>
+                <VAlert v-if="helperInfo" type="success" variant="tonal" density="compact" class="mt-2 text-caption">helper 正常，数据库：{{ helperInfo }}</VAlert>
+              </div>
+
+              <div v-show="activeTab === 'records'" class="ptb-pane">
+                <div class="d-flex align-center flex-wrap ga-1 mb-3"><div class="ptb-section-title mb-0">补全记录</div><VSpacer /><VBtn icon="mdi-refresh" variant="text" size="small" :loading="loadingRuntime" @click="loadRuntimeData" /></div>
+                <div class="d-flex align-center mb-2"><div class="ptb-block-title">最近一次补全</div><VSpacer /><VBtn v-if="lastPlay" color="grey" variant="text" size="x-small" prepend-icon="mdi-broom" :loading="clearing === 'last'" @click="clearData('last_play_result')">清理</VBtn></div>
+                <template v-if="lastPlay">
+                  <div v-if="lastPlay.label" class="text-body-2 font-weight-medium mb-2">{{ lastPlay.label }}</div>
+                  <div class="ptb-stat-grid mb-3"><StatCard label="本次条目" :value="lastPlay.strm_parts" /><StatCard label="已解析" :value="lastPlay.resolved" /><StatCard label="Emby 命中" :value="lastPlay.emby_hits" /><StatCard label="ffprobe 命中" :value="lastPlay.ffprobe_hits" /><StatCard label="写入成功" :value="lastPlay.written_ok" /><StatCard label="写入失败" :value="lastPlay.write_failed" /></div>
+                  <VTable v-if="lastPlay.items?.length" density="compact" class="ptb-history"><thead><tr><th>条目</th><th>状态</th></tr></thead><tbody><tr v-for="(item, index) in lastPlay.items" :key="index"><td class="text-caption">{{ item.label || ('part ' + item.part_id) }}</td><td><VChip :color="statusColor(item.status)" size="x-small" variant="tonal">{{ statusLabel(item.status) }}</VChip><span v-if="item.error" class="text-caption text-error ml-2">{{ item.error }}</span></td></tr></tbody></VTable>
+                </template>
+                <VAlert v-else type="info" variant="tonal" density="compact" class="text-caption">暂无补全记录。</VAlert>
+                <VAlert v-if="lastPlay?.helper_busy" type="warning" variant="tonal" density="compact" class="mt-3 text-caption">Plex 当前繁忙，本次未写入。</VAlert>
+                <VDivider class="my-4" />
+                <div class="d-flex align-center mb-2"><div class="ptb-block-title">补全历史（最近 {{ history.length }} 条）</div><VSpacer /><VBtn v-if="history.length" color="grey" variant="text" size="x-small" prepend-icon="mdi-broom" :loading="clearing === 'history'" @click="clearData('play_history')">清空历史</VBtn></div>
+                <VTable v-if="history.length" density="compact" class="ptb-history"><thead><tr><th>时间</th><th>条目</th><th>结果</th></tr></thead><tbody><template v-for="(row, index) in history" :key="index"><tr class="ptb-row" @click="expanded = expanded === index ? -1 : index"><td>{{ fmtTime(row.ts || row.time || row.created_at) }}</td><td>{{ row.label || '-' }}</td><td>{{ row.written_ok || 0 }} 成功 / {{ row.write_failed || 0 }} 失败</td></tr><tr v-if="expanded === index"><td colspan="3" class="ptb-detail-cell"><div v-for="(item, itemIndex) in row.items || []" :key="itemIndex" class="py-1"><VChip :color="statusColor(item.status)" size="x-small" variant="tonal">{{ statusLabel(item.status) }}</VChip><span class="text-caption ml-2">{{ item.label || item.part_id }}</span></div></td></tr></template></tbody></VTable>
+                <VAlert v-else type="info" variant="tonal" density="compact" class="text-caption">暂无历史记录。</VAlert>
+              </div>
+
+              <div v-show="activeTab === 'matching'" class="ptb-pane">
+                <div class="ptb-section-title">目录匹配</div>
+                <VAlert type="info" variant="tonal" density="compact" class="mb-3 text-caption">取消匹配后，条目会按当前 NFO 代理重读。建议先预览影响。</VAlert>
+                <TargetFields />
+                <div class="d-flex ga-2 flex-wrap mt-4"><VBtn color="info" variant="tonal" size="small" :loading="busyKey === 'unmatch_preview'" :disabled="!!busyKey" prepend-icon="mdi-magnify" @click="doUnmatch(true)">预览影响</VBtn><VBtn color="warning" variant="flat" size="small" :loading="busyKey === 'unmatch_run'" :disabled="!!busyKey" prepend-icon="mdi-link-off" @click="doUnmatch(false)">执行取消匹配</VBtn></div>
+                <VAlert v-if="matchingResult" :type="matchingResult.type" variant="tonal" density="compact" class="mt-4 text-caption" style="white-space:pre-wrap">{{ matchingResult.text }}</VAlert>
+              </div>
+
+              <div v-show="activeTab === 'scraping'" class="ptb-pane">
+                <div class="ptb-section-title">刮削与海报</div>
+                <VAlert type="info" variant="tonal" density="compact" class="mb-3 text-caption">扫描缺封面条目并交给 MoviePilot 生成 NFO/封面，或精准补全缺失 poster.jpg。</VAlert>
+                <TargetFields />
+                <div class="ptb-subsection-title mt-4">缺封面刮削</div><div class="d-flex ga-2 flex-wrap"><VBtn color="info" variant="tonal" size="small" :loading="busyKey === 'scan_cover'" :disabled="!!busyKey" prepend-icon="mdi-image-off-outline" @click="doScanCover">扫描缺封面</VBtn><VBtn color="info" variant="tonal" size="small" :loading="busyKey === 'scrape_preview'" :disabled="!!busyKey" prepend-icon="mdi-magnify" @click="doScrape(true)">预览刮削目录</VBtn><VBtn color="success" variant="flat" size="small" :loading="busyKey === 'scrape_run'" :disabled="!!busyKey" prepend-icon="mdi-auto-fix" @click="doScrape(false)">执行刮削</VBtn></div>
+                <VDivider class="my-4" /><div class="ptb-subsection-title">缺 poster.jpg 精准补全</div><div class="d-flex ga-2 flex-wrap"><VBtn color="info" variant="tonal" size="small" :loading="busyKey === 'poster_preview'" :disabled="!!busyKey" prepend-icon="mdi-magnify" @click="doFixPoster(true)">预览缺 poster</VBtn><VBtn color="success" variant="flat" size="small" :loading="busyKey === 'poster_run'" :disabled="!!busyKey" prepend-icon="mdi-image-plus" @click="doFixPoster(false)">执行补全</VBtn></div>
+                <VAlert v-if="scrapingResult" :type="scrapingResult.type" variant="tonal" density="compact" class="mt-4 text-caption" style="white-space:pre-wrap">{{ scrapingResult.text }}</VAlert>
+              </div>
+
+              <div v-show="activeTab === 'merge'" class="ptb-pane">
+                <div class="ptb-section-title">合并重复条目</div>
+                <VAlert type="info" variant="tonal" density="compact" class="mb-3 text-caption">扫描 Plex 全部剧集/电影库中 tmdb id 相同的重复条目，合并为一个（保留集数最多的条目作主）。</VAlert>
+                <div class="d-flex ga-2 flex-wrap mb-3">
+                  <VBtn color="info" variant="tonal" size="small" :loading="busyKey === 'merge_scan'" :disabled="!!busyKey" prepend-icon="mdi-magnify" @click="doMergeScan">扫描重复</VBtn>
+                  <VBtn v-if="mergeGroups.length" color="success" variant="flat" size="small" :loading="busyKey === 'merge_run'" :disabled="!!busyKey" prepend-icon="mdi-call-merge" @click="doMergeExecute">合并全部（{{ mergeGroups.length }} 组）</VBtn>
+                </div>
+                <template v-if="mergeGroups.length">
+                  <div class="text-caption text-medium-emphasis mb-2">共 {{ mergeGroups.length }} 组重复</div>
+                  <VTable density="compact" class="ptb-history">
+                    <thead><tr><th>剧集 / 电影</th><th>TMDB</th><th>重复条目</th></tr></thead>
+                    <tbody>
+                      <tr v-for="(group, gi) in mergeGroups" :key="gi">
+                        <td class="text-caption">{{ group.title }}</td>
+                        <td class="text-caption">{{ group.guid_id }}</td>
+                        <td class="text-caption">
+                          <div v-for="(item, ii) in group.items" :key="ii" :class="{ 'font-weight-bold': ii === 0 }">
+                            [{{ item.section_title }}] {{ item.title }}（{{ item.year }}）— {{ item.leaf_count }} 集
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </VTable>
+                </template>
+                <VAlert v-else-if="mergeScanned" type="success" variant="tonal" density="compact" class="mt-2 text-caption">未发现重复条目。</VAlert>
+                <VAlert v-if="mergeResult" :type="mergeResult.type" variant="tonal" density="compact" class="mt-4 text-caption" style="white-space:pre-wrap">{{ mergeResult.text }}</VAlert>
+              </div>
+            </div>
+
+            <aside class="ptb-dashboard" aria-label="运行表盘">
+              <section><div class="ptb-dashboard-title"><VIcon icon="mdi-clock-outline" color="primary" size="20" />运行节奏</div><DashboardRow icon="mdi-motion-play-outline" label="播前补全" :value="triggerText" /><DashboardRow icon="mdi-skip-forward-outline" label="播前追加" :value="`后 ${config.forward_episodes || 0} 集`" /><DashboardRow icon="mdi-timer-outline" label="去重窗口" :value="`${config.dedup_window || 0} 秒`" /><DashboardRow icon="mdi-heart-pulse" label="Helper 检查" value="每 5 分钟" /></section>
+              <VDivider class="my-3" />
+              <section><div class="ptb-dashboard-title"><VIcon icon="mdi-chart-box-outline" color="primary" size="20" />运行概况</div><DashboardRow icon="mdi-swap-horizontal-bold" label="代理服务" :value="status.proxy_running ? '运行中' : '未运行'" /><DashboardRow icon="mdi-lan-connect" label="Helper" :value="helperStatusText" /><DashboardRow icon="mdi-database-search-outline" label="媒体数据源" :value="config.use_emby && config.emby_url && config.emby_apikey && config.use_ffprobe ? 'Emby → ffprobe' : (config.use_emby && config.emby_url && config.emby_apikey ? 'Emby' : (config.use_ffprobe ? 'ffprobe' : '未启用'))" /><DashboardRow icon="mdi-history" label="最近补全" :value="lastRunText" /><DashboardRow icon="mdi-database-check-outline" label="最近写入" :value="lastWriteText" /><DashboardRow icon="mdi-folder-multiple-outline" label="补全媒体库" :value="`${selectedSections.length} 个`" /></section>
+            </aside>
+          </div>
+
+        </section>
+      </div>
+    </VCard>
+
+    <VBottomSheet v-model="mobileTabSheet"><VCard><VCardTitle class="text-subtitle-1">选择功能</VCardTitle><VList nav><VListItem v-for="item in tabs" :key="item.key" :active="activeTab === item.key" :title="item.title" :subtitle="item.desc" @click="activeTab = item.key; mobileTabSheet = false"><template #prepend><VIcon :icon="item.icon" /></template></VListItem></VList></VCard></VBottomSheet>
+    <VSnackbar v-model="saveSnackbar" color="success" location="top" :timeout="2200">{{ saveMessage }}</VSnackbar>
+  </div>
+</template>
+
+<script setup>
+import { computed, defineComponent, h, onMounted, reactive, ref, resolveComponent, watch } from 'vue'
+import { getPluginApi, postPluginApi } from './api.js'
+
+const props = defineProps({ initialConfig: { type: Object, default: () => ({}) }, api: { type: [Object, Function], default: null } })
+const emit = defineEmits(['save', 'close', 'layout'])
+const layoutRequest = { maxWidth: '70rem' }
+emit('layout', layoutRequest)
+const VIconComponent = resolveComponent('VIcon')
+const VSelectComponent = resolveComponent('VSelect')
+const VTextFieldComponent = resolveComponent('VTextField')
+
+const tabs = [
+  { key: 'proxy', title: '反向代理', icon: 'mdi-swap-horizontal-bold', desc: 'Plex 播放流 302 直链跳转' },
+  { key: 'mediainfo', title: '媒体信息补全', icon: 'mdi-information-outline', desc: '为 STRM 条目补全媒体流信息' },
+  { key: 'records', title: '补全记录', icon: 'mdi-history', desc: '最近一次补全与历史执行记录' },
+  { key: 'matching', title: '目录匹配', icon: 'mdi-link-variant-off', desc: '预览并执行取消匹配重读 NFO' },
+  { key: 'scraping', title: '刮削与海报', icon: 'mdi-image-search-outline', desc: '缺封面扫描、刮削和 poster 补全' },
+  { key: 'merge', title: '合并重复', icon: 'mdi-call-merge', desc: '扫描并合并 tmdb id 相同的重复条目' },
+]
+const activeTab = ref('proxy')
+const currentTab = computed(() => tabs.find(item => item.key === activeTab.value) || tabs[0])
+const mobileTabSheet = ref(false)
+const error = ref('')
+const checking = ref(false)
+const loadingSections = ref(false)
+const loadingRuntime = ref(false)
+const saving = ref(false)
+const saveMessage = ref('')
+const saveSnackbar = ref(false)
+const helperInfo = ref('')
+const sectionOptions = ref([])
+const status = ref({})
+const lastPlay = ref(null)
+const history = ref([])
+const expanded = ref(-1)
+const clearing = ref('')
+const scrapeSection = ref('')
+const scrapeLimit = ref(0)
+const busyKey = ref('')
+const matchingResult = ref(null)
+const scrapingResult = ref(null)
+const mergeGroups = ref([])
+const mergeScanned = ref(false)
+const mergeResult = ref(null)
+
+const helperDocUrl = 'https://github.com/ranzhigg/MoviePilot-Plugins/blob/main/plugins.v3/plextoolbox/helper/README.md'
+const defaults = { enabled: false, proxy_enabled: false, plex_host: '', plex_token: '', host: '0.0.0.0', port: 32401, pin_rules: '', force_direct_play: true, mediainfo_enabled: false, plex_direct_host: '', helper_url: '', helper_token: '', emby_url: '', emby_apikey: '', use_emby: true, use_ffprobe: true, ffprobe_path_map: '/Volumes/data=/media', ffprobe_timeout: 40, overwrite_streams: true, only_missing: true, concurrency: 3, sections: '', webhook_enabled: false, dedup_window: 300, forward_episodes: 5 }
+const config = reactive({ ...defaults, ...props.initialConfig })
+const savedBaseline = ref(JSON.parse(JSON.stringify(defaults)))
+
+watch(() => props.initialConfig, value => { if (!value || typeof value !== 'object' || !Object.keys(value).length) return; Object.assign(config, value); snapshotBaseline() }, { deep: true })
+watch(activeTab, () => emit('layout', layoutRequest))
+
+const selectedSections = computed({ get: () => config.sections ? String(config.sections).split(',').map(item => item.trim()).filter(Boolean) : [], set: value => { config.sections = (value || []).join(',') } })
+function normalizeValue(value) { if (Array.isArray(value)) return JSON.stringify([...value].sort()); if (value === undefined || value === null) return ''; return String(value) }
+const changedCount = computed(() => Object.keys(defaults).filter(key => normalizeValue(config[key]) !== normalizeValue(savedBaseline.value[key])).length)
+const triggerText = computed(() => !config.mediainfo_enabled ? '未启用' : '当前条目 + 后续集')
+const helperStatusText = computed(() => { if (helperInfo.value || status.value.helper_health_ok === true) return '正常'; if (status.value.helper_health_ok === false) return `异常（连续 ${status.value.helper_health_failures || 1} 次）`; return config.helper_url ? '等待检查' : '未配置' })
+const lastRunText = computed(() => lastPlay.value ? fmtTime(lastPlay.value.ts || lastPlay.value.time || lastPlay.value.created_at) : '暂无')
+const lastWriteText = computed(() => lastPlay.value ? `${lastPlay.value.written_ok || 0} 成功 / ${lastPlay.value.write_failed || 0} 失败` : '暂无')
+
+const DashboardRow = defineComponent({ props: { icon: String, label: String, value: [String, Number] }, setup(rowProps) { return () => h('div', { class: 'ptb-dashboard-row' }, [h(VIconComponent, { icon: rowProps.icon, size: 18 }), h('span', rowProps.label), h('strong', String(rowProps.value ?? '-'))]) } })
+const StatCard = defineComponent({ props: { label: String, value: [String, Number] }, setup(cardProps) { return () => h('div', { class: 'ptb-stat' }, [h('div', { class: 'ptb-stat-value' }, String(cardProps.value ?? '-')), h('div', { class: 'ptb-stat-label' }, cardProps.label)]) } })
+const TargetFields = defineComponent({ setup() { return () => h('div', { class: 'ptb-target-grid' }, [h(VSelectComponent, { modelValue: scrapeSection.value, 'onUpdate:modelValue': value => { scrapeSection.value = value }, items: sectionOptions.value, itemTitle: 'title', itemValue: 'value', label: '目标 Plex 媒体库', variant: 'outlined', density: 'compact', hideDetails: 'auto', loading: loadingSections.value }), h(VTextFieldComponent, { modelValue: scrapeLimit.value, 'onUpdate:modelValue': value => { scrapeLimit.value = Number(value) || 0 }, type: 'number', min: 0, label: '限制条数（0=不限）', variant: 'outlined', density: 'compact', hideDetails: 'auto' })]) } })
+
+function statusLabel(value) { return ({ written: '已写入', resolved: '已解析', unresolved: '未命中', write_failed: '写入失败', busy: 'Plex忙' })[value] || (value || '-') }
+function statusColor(value) { return ({ written: 'success', resolved: 'teal', unresolved: 'orange', write_failed: 'error', busy: 'warning' })[value] || 'grey' }
+function fmtTime(value) { if (!value) return '-'; const numeric = Number(value); const date = Number.isFinite(numeric) ? new Date(numeric > 100000000000 ? numeric : numeric * 1000) : new Date(value); if (Number.isNaN(date.getTime())) return String(value); const pad = item => String(item).padStart(2, '0'); return `${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}` }
+function showMatching(type, text) { matchingResult.value = { type, text } }
+function showScraping(type, text) { scrapingResult.value = { type, text } }
+
+async function loadSections() { loadingSections.value = true; try { const response = await getPluginApi(props.api, 'sections'); if (!response?.success) throw new Error(response?.error || '获取媒体库失败'); sectionOptions.value = (response.sections || []).map(item => ({ title: `${item.title}（${item.type}）`, value: String(item.key) })) } catch (exception) { error.value = String(exception) } finally { loadingSections.value = false } }
+async function loadRuntimeData() { loadingRuntime.value = true; try { const [runtimeStatus, result] = await Promise.all([getPluginApi(props.api, 'status'), getPluginApi(props.api, 'result')]); status.value = runtimeStatus || {}; lastPlay.value = result?.last_play_result || null; history.value = Array.isArray(result?.play_history) ? result.play_history : [] } catch (exception) { error.value = String(exception) } finally { loadingRuntime.value = false } }
+function snapshotBaseline() { savedBaseline.value = JSON.parse(JSON.stringify({ ...defaults, ...config })) }
+async function loadConfig() { try { const response = await getPluginApi(props.api, 'config'); const persisted = response?.data || response; if (persisted && typeof persisted === 'object') Object.assign(config, persisted); snapshotBaseline() } catch (exception) { error.value = String(exception) } }
+async function checkHelper() { checking.value = true; helperInfo.value = ''; try { const response = await getPluginApi(props.api, 'helper_check'); if (!response?.success) throw new Error(response?.error || 'helper 检查失败'); helperInfo.value = response?.dbinfo?.db_path || '已连接' } catch (exception) { error.value = String(exception) } finally { checking.value = false } }
+async function clearData(target) { clearing.value = target === 'play_history' ? 'history' : 'last'; try { const response = await postPluginApi(props.api, 'clear_completion_data', { target }); if (!response?.success) throw new Error(response?.error || '清理失败'); if (target === 'play_history') history.value = []; else lastPlay.value = null; expanded.value = -1 } catch (exception) { error.value = String(exception) } finally { clearing.value = '' } }
+
+async function doUnmatch(dryRun) { if (!scrapeSection.value) return showMatching('warning', '请先选择目标媒体库'); if (!dryRun && !window.confirm('确认对该媒体库执行取消匹配？条目将被打回未匹配并按当前 NFO 代理重读。')) return; busyKey.value = dryRun ? 'unmatch_preview' : 'unmatch_run'; matchingResult.value = null; try { const response = await postPluginApi(props.api, 'unmatch', { section: scrapeSection.value, dry_run: dryRun, rematch: true, limit: Number(scrapeLimit.value) || 0 }); if (!response?.success) throw new Error(response?.error || '操作失败'); showMatching(dryRun ? 'info' : 'success', dryRun ? `预览：该库共 ${response.total_items} 个条目，将影响 ${response.will_affect} 个` : `已取消匹配 ${response.unmatched} 个，刷新重读 ${response.refreshed} 个，失败 ${response.failed} 个`) } catch (exception) { showMatching('error', String(exception)) } finally { busyKey.value = '' } }
+async function doScanCover() { if (!scrapeSection.value) return showScraping('warning', '请先选择目标媒体库'); busyKey.value = 'scan_cover'; try { const response = await postPluginApi(props.api, 'scan_cover', { section: scrapeSection.value }); if (!response?.success) throw new Error(response?.error || '扫描失败'); const list = (response.missing || []).slice(0, 20).map(item => `· ${item.title}（${item.reason}）`).join('\n'); showScraping('info', `已检查 ${response.checked} 个条目，缺封面 ${response.total} 个${list ? '：\n' + list : ''}`) } catch (exception) { showScraping('error', String(exception)) } finally { busyKey.value = '' } }
+async function doScrape(dryRun) { if (!scrapeSection.value) return showScraping('warning', '请先选择目标媒体库'); if (!dryRun && !window.confirm('确认对缺封面条目执行 MoviePilot 刮削？将生成 NFO+封面文件。')) return; busyKey.value = dryRun ? 'scrape_preview' : 'scrape_run'; try { const response = await postPluginApi(props.api, 'scrape', { section: scrapeSection.value, dry_run: dryRun, limit: Number(scrapeLimit.value) || 0, unmatch_after: false }); if (!response?.success) throw new Error(response?.error || '刮削失败'); const list = (response.targets || []).slice(0, 20).map(item => `· ${item.title} → ${item.dir}`).join('\n'); showScraping(dryRun ? 'info' : 'success', dryRun ? `待刮削 ${response.candidates} 个目录${list ? '：\n' + list : ''}` : `刮削成功 ${response.scraped} 个，已刷新 ${response.refreshed || 0} 个，失败 ${response.failed} 个`) } catch (exception) { showScraping('error', String(exception)) } finally { busyKey.value = '' } }
+async function doFixPoster(dryRun) { if (!scrapeSection.value) return showScraping('warning', '请先选择目标媒体库'); if (!dryRun && !window.confirm('确认为缺 poster.jpg 的条目执行补全？剧集优先复制季内海报，其余从 TMDB 下载。')) return; busyKey.value = dryRun ? 'poster_preview' : 'poster_run'; try { const response = await postPluginApi(props.api, 'fix_poster', { section: scrapeSection.value, dry_run: dryRun, limit: Number(scrapeLimit.value) || 0 }); if (!response?.success) throw new Error(response?.error || '操作失败'); const list = (response.targets || []).slice(0, 20).map(item => `· ${item.title} → ${item.dir}`).join('\n'); showScraping(dryRun ? 'info' : (response.failed ? 'warning' : 'success'), dryRun ? `已检查 ${response.checked} 个条目，缺 poster ${response.candidates} 个${list ? '：\n' + list : ''}` : `补全成功 ${response.fixed} 个（已刷新 ${response.refreshed}），失败 ${response.failed} 个`) } catch (exception) { showScraping('error', String(exception)) } finally { busyKey.value = '' } }
+
+async function doMergeScan() { busyKey.value = 'merge_scan'; mergeResult.value = null; mergeGroups.value = []; mergeScanned.value = false; try { const response = await getPluginApi(props.api, 'merge_scan'); if (!response?.success) throw new Error(response?.error || '扫描失败'); mergeGroups.value = response.groups || []; mergeScanned.value = true; if (!mergeGroups.value.length) mergeResult.value = { type: 'success', text: '未发现重复条目' } } catch (exception) { mergeResult.value = { type: 'error', text: String(exception) } } finally { busyKey.value = '' } }
+async function doMergeExecute() { if (!mergeGroups.value.length) return; if (!window.confirm(`确认合并 ${mergeGroups.value.length} 组重复条目？每组保留集数最多的条目，其余并入。`)) return; busyKey.value = 'merge_run'; mergeResult.value = null; try { const merges = mergeGroups.value.map(group => { const sorted = [...group.items].sort((a, b) => (Number(b.leaf_count) || 0) - (Number(a.leaf_count) || 0)); return { primary: sorted[0].rating_key, others: sorted.slice(1).map(item => item.rating_key) } }); const response = await postPluginApi(props.api, 'merge_execute', { merges }); if (!response?.success) throw new Error(response?.error || '合并失败'); const msg = `合并成功 ${response.merged} 组${response.failed?.length ? '，失败 ' + response.failed.length + ' 组' : ''}`; busyKey.value = ''; await doMergeScan(); mergeResult.value = { type: 'success', text: msg + '（已重新扫描）' } } catch (exception) { mergeResult.value = { type: 'error', text: String(exception) } } finally { busyKey.value = '' } }
+
+async function saveConfig() { const payload = { ...config }; error.value = ''; saving.value = true; try { const response = await postPluginApi(props.api, 'config', payload); if (!response?.success) throw new Error(response?.message || response?.error || '配置保存失败'); const verify = await getPluginApi(props.api, 'config'); const persisted = verify?.data || verify; if (persisted && typeof persisted === 'object') Object.assign(config, persisted); snapshotBaseline(); saveMessage.value = '配置已保存并生效'; saveSnackbar.value = true } catch (exception) { error.value = exception?.message || String(exception) } finally { saving.value = false } }
+onMounted(async () => { emit('layout', layoutRequest); await loadConfig(); await loadRuntimeData(); if (config.plex_token && (config.plex_direct_host || config.plex_host)) loadSections() })
+</script>
+
+<style scoped>
+.ptb-config { container-type: inline-size; width: min(1120px, calc(100vw - 48px)); max-width: 100%; height: calc(100dvh - 16px); max-height: calc(100dvh - 16px); padding: 8px; margin: 0 auto; display: flex; }
+.ptb-card { width: 100%; height: 100%; min-height: 0; display: flex; flex-direction: column; border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity)); border-radius: 14px; overflow: hidden; }
+.ptb-header { padding: 14px 18px; }
+.ptb-header-subtitle { max-width: min(560px, 52vw); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ptb-body { flex: 1 1 auto; min-height: 0; display: flex; }
+.ptb-nav { width: 168px; flex: 0 0 168px; border-right: 1px solid rgba(var(--v-border-color), var(--v-border-opacity)); background: rgba(var(--v-theme-on-surface), .02); }
+.ptb-nav-item { margin: 2px 8px; }
+.ptb-content { flex: 1 1 auto; min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+.ptb-error-alert { flex: 0 0 auto; min-height: 44px; }
+.ptb-dirty-hint { display: flex; align-items: center; }
+.ptb-mobile-tabbar { display: none; }
+.ptb-workspace { flex: 1 1 auto; min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow-y: auto; }
+.ptb-window { flex: 0 0 auto; min-width: 0; }
+.ptb-pane { padding: 18px 20px; }
+.ptb-section-title { color: rgb(var(--v-theme-primary)); font-size: 14px; font-weight: 700; margin-bottom: 12px; }
+.ptb-subsection-title, .ptb-block-title { font-size: 13px; font-weight: 700; }
+.ptb-doc-link { color: rgb(var(--v-theme-primary)); text-decoration: underline; font-weight: 600; }
+.ptb-target-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(130px, 1fr); gap: 12px; }
+.ptb-stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 10px; }
+.ptb-stat { padding: 10px 12px; border-left: 3px solid rgb(var(--v-theme-primary)); border-radius: 8px; background: rgba(var(--v-theme-on-surface), .03); }
+.ptb-stat-value { font-size: 1.25rem; font-weight: 700; }
+.ptb-stat-label { font-size: .75rem; opacity: .7; }
+.ptb-history th { font-size: .72rem; opacity: .7; }
+.ptb-row { cursor: pointer; }
+.ptb-detail-cell { background: rgba(var(--v-theme-on-surface), .03); }
+.ptb-dashboard { flex: 0 0 auto; margin: 0 12px 12px; padding: 14px 16px; border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity)); border-radius: 8px; background: rgba(var(--v-theme-on-surface), .015); }
+.ptb-dashboard-title { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; font-size: 14px; font-weight: 700; }
+.ptb-dashboard-row { display: grid; grid-template-columns: 24px minmax(0, 1fr) auto; align-items: center; gap: 8px; min-height: 38px; color: rgba(var(--v-theme-on-surface), .68); font-size: 13px; }
+.ptb-dashboard-row strong { color: rgb(var(--v-theme-on-surface)); text-align: right; overflow-wrap: anywhere; }
+@container (min-width: 880px) { .ptb-workspace { display: grid; grid-template-columns: minmax(0, 1fr) 252px; overflow: hidden; } .ptb-window { min-height: 0; overflow-y: auto; } .ptb-dashboard { margin: 0; padding: 18px 16px; border-width: 0 0 0 1px; border-radius: 0; overflow-y: auto; } }
+@media (max-width: 640px) { .ptb-config { width: 100%; height: 100dvh; max-height: 100dvh; padding: 0; } .ptb-card { border: 0; border-radius: 0; } .ptb-header { padding: 8px 10px; } .ptb-header-title { font-size: 15px; } .ptb-dirty-hint { display: none; } .ptb-body { flex-direction: column; } .ptb-nav { display: none; } .ptb-mobile-tabbar { display: flex; align-items: center; gap: 10px; padding: 10px 12px; border-bottom: 1px solid rgba(var(--v-border-color), var(--v-border-opacity)); } .ptb-mobile-tabinfo { flex: 1 1 auto; min-width: 0; } .ptb-pane { padding: 12px; } .ptb-target-grid { grid-template-columns: 1fr; } }
+</style>

--- a/plugins.v3/plextoolbox/src/components/Page.vue
+++ b/plugins.v3/plextoolbox/src/components/Page.vue
@@ -1,0 +1,40 @@
+<template>
+  <Config
+    :initial-config="initialConfig"
+    :api="api"
+    @save="onSave"
+    @close="emit('close')"
+    @layout="payload => emit('layout', payload)"
+  />
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import Config from './Config.vue'
+
+const props = defineProps({
+  api: { type: Object, default: () => ({}) },
+})
+
+const emit = defineEmits(['action', 'close', 'layout'])
+const initialConfig = ref({})
+
+function unwrap(response) {
+  const body = response?.data ?? response ?? {}
+  return body?.data ?? body
+}
+
+async function onSave(payload) {
+  await props.api.post('plugin/PlexToolbox/config', payload)
+  emit('action')
+}
+
+onMounted(async () => {
+  try {
+    const response = await props.api.get('plugin/PlexToolbox/config')
+    initialConfig.value = unwrap(response) || {}
+  } catch (error) {
+    console.error('读取 PLEX 工具箱配置失败', error)
+  }
+})
+</script>

--- a/plugins.v3/plextoolbox/src/components/api.js
+++ b/plugins.v3/plextoolbox/src/components/api.js
@@ -1,0 +1,15 @@
+export function unwrapResponse(response) {
+  const data = response?.data ?? response
+  if (data && typeof data === 'object' && 'data' in data) return data.data
+  return data
+}
+
+export async function getPluginApi(api, path) {
+  if (!api?.get) throw new Error('缺少 MoviePilot 注入的 api.get')
+  return unwrapResponse(await api.get(`plugin/PlexToolbox/${path}`))
+}
+
+export async function postPluginApi(api, path, payload = {}) {
+  if (!api?.post) throw new Error('缺少 MoviePilot 注入的 api.post')
+  return unwrapResponse(await api.post(`plugin/PlexToolbox/${path}`, payload))
+}

--- a/plugins.v3/plextoolbox/src/main.js
+++ b/plugins.v3/plextoolbox/src/main.js
@@ -1,0 +1,2 @@
+export { default as Config } from './components/Config.vue'
+export { default as Page } from './components/Page.vue'

--- a/plugins.v3/plextoolbox/tests/test_ffprobe_source.py
+++ b/plugins.v3/plextoolbox/tests/test_ffprobe_source.py
@@ -1,0 +1,187 @@
+"""PlexToolbox ffprobe 数据源与无 Emby 回退逻辑的纯 Python 自测。"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+if str(PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_DIR))
+
+from ffprobe_source import (  # noqa: E402
+    FfprobeSource,
+    _normalize_ffprobe,
+    map_path,
+    parse_path_map,
+    read_strm_url,
+)
+
+
+class FfprobeSourceTest(unittest.TestCase):
+    """覆盖 STRM 读取、路径映射和 ffprobe JSON 归一化。"""
+
+    def test_path_mapping_prefers_longest_prefix(self) -> None:
+        mappings = parse_path_map(
+            "/Volumes/data=/media\n/Volumes/data/mp=/special; /invalid=relative"
+        )
+        self.assertEqual(
+            map_path("/Volumes/data/mp/movie.strm", mappings),
+            "/special/movie.strm",
+        )
+        self.assertEqual(map_path("/Volumes/other/movie.strm", mappings), "/Volumes/other/movie.strm")
+
+    def test_read_strm_url_skips_comments_and_blank_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            strm = Path(temp_dir) / "movie.strm"
+            strm.write_text("# generated\n\nhttps://example.invalid/movie.mkv?pickcode=redacted\n", encoding="utf-8")
+            self.assertEqual(
+                read_strm_url(str(strm)),
+                "https://example.invalid/movie.mkv?pickcode=redacted",
+            )
+
+    def test_normalize_ffprobe_output(self) -> None:
+        result = _normalize_ffprobe(
+            {
+                "format": {
+                    "format_name": "matroska,webm",
+                    "duration": "1420.125",
+                    "size": "2147483648",
+                    "bit_rate": "12000000",
+                },
+                "streams": [
+                    {
+                        "index": 0,
+                        "codec_type": "video",
+                        "codec_name": "hevc",
+                        "width": 1920,
+                        "height": 1080,
+                        "avg_frame_rate": "24000/1001",
+                        "pix_fmt": "yuv420p10le",
+                        "bit_rate": "10000000",
+                        "tags": {"LANGUAGE": "und"},
+                    },
+                    {
+                        "index": 1,
+                        "codec_type": "audio",
+                        "codec_name": "eac3",
+                        "channels": 6,
+                        "sample_rate": "48000",
+                        "bit_rate": "640000",
+                        "tags": {"language": "jpn"},
+                    },
+                    {
+                        "index": 2,
+                        "codec_type": "subtitle",
+                        "codec_name": "subrip",
+                        "tags": {"language": "chi"},
+                    },
+                    {"index": 3, "codec_type": "data", "codec_name": "bin_data"},
+                ],
+            }
+        )
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["container"], "mkv")
+        self.assertEqual(result["duration"], 1420125)
+        self.assertEqual(result["bitrate"], 12000)
+        self.assertEqual(result["video_codec"], "hevc")
+        self.assertEqual(result["audio_codec"], "eac3")
+        self.assertEqual(result["audio_channels"], 6)
+        self.assertEqual(len(result["streams"]), 3)
+        self.assertEqual(result["streams"][0]["bit_depth"], 10)
+        self.assertEqual(result["streams"][0]["frame_rate"], 23.976)
+        self.assertEqual(result["streams"][2]["codec"], "srt")
+
+    def test_source_reads_mapped_strm_and_probes_url(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plex_root = Path(temp_dir) / "plex"
+            mp_root = Path(temp_dir) / "mp"
+            mp_root.mkdir()
+            strm = mp_root / "movie.strm"
+            strm.write_text("https://example.invalid/movie.mkv\n", encoding="utf-8")
+            source = FfprobeSource(f"{plex_root}={mp_root}", timeout=7)
+            expected = {"source": "ffprobe", "streams": [{"stream_type": 1, "codec": "hevc"}]}
+            with patch("ffprobe_source.ffprobe_url", return_value=expected) as probe:
+                self.assertEqual(source.find_streams_by_name(f"{plex_root}/movie.strm"), expected)
+                probe.assert_called_once_with("https://example.invalid/movie.mkv", timeout=7.0)
+
+
+class FfprobeFallbackTest(unittest.TestCase):
+    """验证关闭 Emby 后 MediaInfoCompleter 仍能走 ffprobe。"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # mediainfo.py 使用 MoviePilot 的 logger；测试时提供最小模块桩，
+        # 不需要启动 MoviePilot 或连接 Plex/helper。
+        app = types.ModuleType("app")
+        app.__path__ = []
+        sdk = types.ModuleType("app.sdk")
+        sdk.__path__ = []
+        logging_module = types.ModuleType("app.sdk.logging")
+        import logging
+
+        logging_module.logger = logging.getLogger("plextoolbox-test")
+        sys.modules.setdefault("app", app)
+        sys.modules.setdefault("app.sdk", sdk)
+        sys.modules.setdefault("app.sdk.logging", logging_module)
+
+        # 仅为导入 Plex/Emby/helper 客户端提供最小 httpx 桩；本测试不发网络请求。
+        if "httpx" not in sys.modules:
+            httpx = types.ModuleType("httpx")
+
+            class ClientStub:
+                pass
+
+            httpx.Client = ClientStub
+            sys.modules["httpx"] = httpx
+
+        package = types.ModuleType("plextoolbox")
+        package.__path__ = [str(PLUGIN_DIR)]
+        sys.modules.setdefault("plextoolbox", package)
+        cls.completer_module = importlib.import_module("plextoolbox.mediainfo")
+
+    def test_no_emby_uses_ffprobe(self) -> None:
+        module = self.completer_module
+
+        class PlexStub:
+            def item_label(self, rating_key: str) -> str:
+                return "测试电影"
+
+            def collect_window_parts_by_rating_key(self, rating_key: str, **kwargs):
+                return [{"part_id": 12, "file": "/media/test.strm", "label": "测试电影"}]
+
+        class HelperStub:
+            def write_batch(self, items, force=False):
+                return {
+                    "ok": len(items),
+                    "results": [{"part_id": 12, "success": True}],
+                }
+
+        class ProbeStub:
+            def find_streams_by_name(self, file_path: str):
+                return {"source": "ffprobe", "streams": [{"stream_type": 1, "codec": "hevc"}]}
+
+        completer = module.MediaInfoCompleter(
+            plex=PlexStub(),
+            helper=HelperStub(),
+            emby=None,
+            use_emby=False,
+            ffprobe=ProbeStub(),
+            use_ffprobe=True,
+        )
+        summary = completer.run_rating_key("138375")
+        self.assertEqual(summary["resolved"], 1)
+        self.assertEqual(summary["ffprobe_hits"], 1)
+        self.assertEqual(summary["emby_hits"], 0)
+        self.assertEqual(summary["written_ok"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins.v3/plextoolbox/vite.config.js
+++ b/plugins.v3/plextoolbox/vite.config.js
@@ -1,0 +1,77 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import federation from '@originjs/vite-plugin-federation'
+import { rmSync } from 'node:fs'
+
+function removeUnreachableSharedAssets() {
+  return {
+    name: 'remove-unreachable-shared-assets',
+    closeBundle() {
+      rmSync(new URL('./dist/assets/__federation_shared_vuetify', import.meta.url), {
+        recursive: true,
+        force: true,
+      })
+    },
+  }
+}
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    federation({
+      name: 'PlexToolbox',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './Page': './src/components/Page.vue',
+        './Config': './src/components/Config.vue',
+      },
+      shared: {
+        vue: {
+          requiredVersion: false,
+          generate: false,
+        },
+        vuetify: {
+          requiredVersion: false,
+          generate: false,
+          singleton: true,
+        },
+        'vuetify/styles': {
+          requiredVersion: false,
+          generate: false,
+          singleton: true,
+        },
+      },
+      format: 'esm',
+    }),
+    removeUnreachableSharedAssets(),
+  ],
+  build: {
+    target: 'esnext',
+    minify: false,
+    cssCodeSplit: true,
+  },
+  css: {
+    postcss: {
+      plugins: [
+        {
+          postcssPlugin: 'internal:charset-removal',
+          AtRule: {
+            charset: atRule => {
+              if (atRule.name === 'charset') atRule.remove()
+            },
+          },
+        },
+        {
+          postcssPlugin: 'vuetify-filter',
+          Root(root) {
+            root.walkRules(rule => {
+              if (rule.selector && (rule.selector.includes('.v-') || rule.selector.includes('.mdi-'))) {
+                rule.remove()
+              }
+            })
+          },
+        },
+      ],
+    },
+  },
+})


### PR DESCRIPTION
## Summary

This PR adds PlexToolbox, a MoviePilot V3 plugin for Plex users whose library
contains STRM entries (especially 115 302 redirect streams).

The plugin provides:

- a Plex-compatible 302 reverse proxy for STRM playback;
- media stream metadata completion for STRM items;
- an optional ffprobe source that reads the URL inside each STRM file directly,
  so Emby is not required;
- a small local helper service that writes media metadata to Plex's SQLite
  database on the Plex host;
- playback-triggered and webhook-triggered incremental completion;
- poster repair, metadata scraping helpers, and TMDB duplicate-entry merging;
- a V3 configuration UI, runtime health information, and self-tests.

## Motivation

Plex can discover and display STRM items, but incomplete media metadata can
cause clients to make poor playback decisions. More importantly, Plex's native
transcoder treats a local .strm file as a text input rather than following the
URL contained in it. STRM playback therefore needs to stay on the direct
play/direct stream path; transcoding the local STRM file is not a viable
fallback.

PlexToolbox keeps the normal Plex library and client workflow while making the
direct-play path reliable:

1. MoviePilot reads the STRM URL and probes the real remote media with ffprobe.
2. The helper writes the discovered media/stream fields into Plex's existing
   database tables.
3. Plex can make a correct direct-play decision and return the STRM Part as a
   301/302 redirect to the remote media URL.

## Implementation details

### Media information

- Enumerates Plex movies and episodes and extracts STRM Parts.
- Supports Emby as an optional source and falls back to ffprobe.
- Supports longest-prefix Plex-host-to-MoviePilot path mapping.
- Reads the first valid HTTP(S) URL from STRM files, skips comments/blank lines,
  follows the 115 redirect through ffprobe, and normalizes the result into
  Plex media/stream fields.
- Uses conservative timeouts and avoids logging URLs that may contain
  authorization parameters.
- Removes the unsupported -nostdin argument for ffprobe builds used by the
  tested deployment.

### Plex helper

- Runs on the Plex host, keeping SQLite writes local to the database file.
- Uses a write lock, SQLite busy timeout, WAL mode, transactions, and
  per-item savepoints.
- Introspects table columns and only writes columns that exist in the current
  Plex schema; it never alters the schema.
- Supports optional database backups, token authentication, Plex-busy checks,
  single-item writes, and batch writes.

### Playback and automation

- Caches Plex Part paths and STRM redirect resolution.
- Coalesces concurrent redirect lookups for the same Part.
- Supports playback-triggered prefetch and Plex webhook-triggered completion
  with a configurable cooldown.
- Provides a direct-play decision path and a configurable 302 proxy for clients
  that need to reach the Plex service through MoviePilot.

### UI and maintenance tools

- Adds V3 configuration for Plex, helper, Emby/ffprobe, path mapping, sections,
  concurrency, and automation settings.
- Adds health/status cards and per-run completion statistics.
- Includes poster repair and TMDB duplicate-library cleanup tools.
- Includes deployment documentation for both a native helper process and
  Docker/Compose.

## Validation

The following checks pass:

~~~text
python3 plugins.v3/plextoolbox/tests/test_ffprobe_source.py
Ran 5 tests ... OK

python3 plugins.v3/plextoolbox/helper/selftest.py
全部自测通过

python3 -m compileall -q plugins.v3/plextoolbox
~~~

The implementation was also tested against a live macOS Plex Media Server and
Plex for iOS with a real H.264/AAC 115 STRM item:

- Plex metadata shows the detected duration and video/audio tracks.
- With direct play enabled, Plex returns MDE=1000, Direct play OK.
- The Part request returns HTTP 301 to the 115 redirect endpoint.
- The iOS client reaches the playing state without a transcoder session.

## Compatibility and safety

- Requires MoviePilot V3 (system_version >= 3.0.0).
- Emby is optional; ffprobe-only operation is supported.
- The helper uses only Python's standard library.
- Database writes are limited to existing Plex media tables and can be
  protected by an access token and optional pre-write backups.
- Direct play/direct stream must be enabled in the client for STRM playback;
  unsupported media still needs a client/server capable of handling the source
  format.

Thank you to the DDSRem-Dev maintainers and contributors for maintaining
MoviePilot-Plugins and the V3 plugin ecosystem. I appreciate the project
structure, release tooling, and review effort, and would be grateful for any
feedback on the plugin scope, naming, and integration details.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 9594a3ab097d6e9f9f3430e9c3442f71144b00be

- 新增 PlexToolbox V3 插件，提供 Plex STRM 302 反代直链与媒体信息补全
  - 代理将 STRM/远程路径播放改为 302 直链，含缓存与单飞解析
  - 新增 ffprobe 数据源，无 Emby 时也能读取 STRM URL 并归一化媒体流
  - 支持播前/Webhook 增量补全、poster 修复、TMDB 重复合并与 Helper 健康检查
  - 附带 ffprobe 单元测试及兼容无 `-nostdin` 的 ffprobe 构建
- 播放链路先补全媒体流再放行，带超时预算避免阻塞起播
- 通过本地 helper 服务写 Plex SQLite，并检测 Helper 异常告警
- 风险点：大型新插件需在目标 MoviePilot V3 与 Plex 环境独立验证
<!-- pr-agent-summary:end -->
